### PR TITLE
evm: add a basic execution environment

### DIFF
--- a/src/evm.zig
+++ b/src/evm.zig
@@ -41,390 +41,393 @@ fn traceOpPush(pc: usize, operand: WORD) void {
 // Meant to print _additional_ information for opcodes which take 2 items off the stack then put 1 back on.
 fn traceStackTake() void {}
 
-pub const EVM = struct {
-    const Self = @This();
-    // TODO: ROM context.
-    // TODO: Nested EVMs.
-    // TODO: Gas.
+pub fn NewEVM(comptime Environment: type) type {
+    return struct {
+        const Self = @This();
+        // TODO: ROM context.
+        // TODO: Nested EVMs.
+        // TODO: Gas.
+        env: *Environment,
 
-    // TODO: Custom data structure for our stack (optimisation).
-    stack: std.BoundedArray(WORD, MAX_STACK_DEPTH),
+        // TODO: Custom data structure for our stack (optimisation).
+        stack: std.BoundedArray(WORD, MAX_STACK_DEPTH),
 
-    /// Program counter / Instruction pointer.
-    // TODO: By spec is a u256, cannot use a u256 to address std.BoundedArray as-is. Fix later.
-    pc: usize,
+        /// Program counter / Instruction pointer.
+        // TODO: By spec is a u256, cannot use a u256 to address std.BoundedArray as-is. Fix later.
+        pc: usize,
 
-    alloc: std.mem.Allocator,
+        alloc: std.mem.Allocator,
 
-    // TODO: Specialised allocators later on, perhaps external allocators passed in from host (where we're potentially embedded).
-    // pub fn init(alloc: std.mem.Allocator) !Self {
-    pub fn init() !Self {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        // TODO: Specialised allocators later on, perhaps external allocators passed in from host (where we're potentially embedded).
+        // pub fn init(alloc: std.mem.Allocator) !Self {
+        pub fn init(env: *Environment) !Self {
+            var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 
-        return Self{
-            // TODO:
-            .alloc = gpa.allocator(),
-            .pc = 0,
-            .stack = try std.BoundedArray(WORD, MAX_STACK_DEPTH).init(0),
-        };
-    }
+            return Self{
+                // TODO:
+                .alloc = gpa.allocator(),
+                .pc = 0,
+                .stack = try std.BoundedArray(WORD, MAX_STACK_DEPTH).init(0),
+                .env = env,
+            };
+        }
 
-    // TODO: Actually is better as inline?
-    inline fn decodeOp(raw_bytecode: u8) OpCode {
-        // If we do want to check for further bytecode then we can probably keep using labelled switch and instead would need to store the bytecode on the vm struct, take the ip as a paramete rhere, check we're within bounds and then return as we currently do.
-        return @as(OpCode, @enumFromInt(raw_bytecode));
-    }
+        // TODO: Actually is better as inline?
+        inline fn decodeOp(raw_bytecode: u8) OpCode {
+            // If we do want to check for further bytecode then we can probably keep using labelled switch and instead would need to store the bytecode on the vm struct, take the ip as a paramete rhere, check we're within bounds and then return as we currently do.
+            return @as(OpCode, @enumFromInt(raw_bytecode));
+        }
 
-    // JORDAN: Function `digits2` in Zig std/fmt.zig interesting.
+        // JORDAN: Function `digits2` in Zig std/fmt.zig interesting.
 
-    // TODO: Have these as a comptime function which will inline flip the sign instead?
+        // TODO: Have these as a comptime function which will inline flip the sign instead?
 
-    inline fn asSignedWord(value: WORD) SIGNED_WORD {
-        return @as(SIGNED_WORD, @bitCast(value));
-    }
+        inline fn asSignedWord(value: WORD) SIGNED_WORD {
+            return @as(SIGNED_WORD, @bitCast(value));
+        }
 
-    inline fn asUnsignedWord(value: SIGNED_WORD) WORD {
-        return @as(WORD, @bitCast(value));
-    }
+        inline fn asUnsignedWord(value: SIGNED_WORD) WORD {
+            return @as(WORD, @bitCast(value));
+        }
 
-    // XXX: Is this actually useful? Trying to make things clearer.
-    inline fn u8Truncate(value: anytype) u8 {
-        return @as(u8, @truncate(value));
-    }
+        // XXX: Is this actually useful? Trying to make things clearer.
+        inline fn u8Truncate(value: anytype) u8 {
+            return @as(u8, @truncate(value));
+        }
 
-    pub fn execute(self: *EVM, rom: []const u8) !void {
-        print("{s:=^60}\n", .{" EVM execute "});
-        // JORDAN: So this labelled switch API is nice but makes adding disassemly and debug information more verbose vs. a while loop over the rom which can invoke any such logic in one-ish place. Beyond inline functions at comptime based on build flags (i.e. if debug build, inline some debug functions) runtime debugging would require a check at every callsite for debug output I think. Is this the cost to pay? Tradeoffs etc.
-        _ = sw: switch (decodeOp(rom[self.pc])) {
-            .STOP => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+        pub fn execute(self: *Self, rom: []const u8) !void {
+            print("{s:=^60}\n", .{" EVM execute "});
+            // JORDAN: So this labelled switch API is nice but makes adding disassemly and debug information more verbose vs. a while loop over the rom which can invoke any such logic in one-ish place. Beyond inline functions at comptime based on build flags (i.e. if debug build, inline some debug functions) runtime debugging would require a check at every callsite for debug output I think. Is this the cost to pay? Tradeoffs etc.
+            _ = sw: switch (decodeOp(rom[self.pc])) {
+                .STOP => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // TODO: Here and for other halt opcodes return with error union so we can execute appropriate post-halt actions.
-                return;
-            },
-            .ADD => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    // TODO: Here and for other halt opcodes return with error union so we can execute appropriate post-halt actions.
+                    return;
+                },
+                .ADD => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // TODO: Here and for other similar log with traceStackTake
+                    // TODO: Here and for other similar log with traceStackTake
 
-                // TODO: Here and elsewhere with simpler modulo logic is this compiled to a bitwise AND? (and for others as appropriate). Use of this form involves peer type resolution so any overheads etc need to be investigated.
-                try self.stack.append(self.stack.pop() +% self.stack.pop());
+                    // TODO: Here and elsewhere with simpler modulo logic is this compiled to a bitwise AND? (and for others as appropriate). Use of this form involves peer type resolution so any overheads etc need to be investigated.
+                    try self.stack.append(self.stack.pop() +% self.stack.pop());
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .MUL => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                try self.stack.append(self.stack.pop() *% self.stack.pop());
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SUB => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                try self.stack.append(self.stack.pop() -% self.stack.pop());
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .DIV => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = numerator ; s[1] = denominator.
-                const numerator = self.stack.pop();
-                const denominator = self.stack.pop();
-
-                // Stack items are unsigned-integers, Zig will do floored division automatically.
-                try self.stack.append(if (denominator == 0) 0 else (numerator / denominator));
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SDIV => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = numerator ; s[1] = denominator.
-                // Both values treated as 2's complement signed 256-bit integers.
-                const numerator: i256 = @bitCast(self.stack.pop());
-                const denominator: i256 = @bitCast(self.stack.pop());
-
-                if (denominator == 0) {
-                    try self.stack.append(0);
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                .MUL => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // TODO: This can be optimised probably, look into it later. For example, before bit-casting we can perform the equivalent checks for -1 and -2^255 by checking for max u256 (i.e. all bits set, which is -1 in two's complement for i256) and whether only the first bit is set as that's maximum negative.
+                    try self.stack.append(self.stack.pop() *% self.stack.pop());
 
-                try self.stack.append(@bitCast(if (denominator == -1 and numerator == std.math.minInt(i256)) std.math.minInt(i256) else @divTrunc(numerator, denominator)));
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .MOD => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = numerator ; s[1] = denominator.
-                const numerator = self.stack.pop();
-                const denominator = self.stack.pop();
-
-                // Stack items are unsigned-integers, Zig will do floored division automatically.
-                try self.stack.append(if (denominator == 0) 0 else (numerator % denominator));
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SMOD => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = numerator ; s[1] = denominator.
-                // Both values treated as 2's complement signed 256-bit integers.
-                const numerator: i256 = @bitCast(self.stack.pop());
-                const denominator: i256 = @bitCast(self.stack.pop());
-
-                try self.stack.append(if (denominator == 0) 0 else @bitCast(@rem(numerator, denominator)));
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .ADDMOD => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0, 1] = addition operands ; s[2] = denominator.
-                // TODO: Definitely a nicer way of implementing this outside of u257 and an intCast; optimise for that later.
-
-                const left: u257 = self.stack.pop();
-                const right = self.stack.pop();
-                const denominator = self.stack.pop();
-
-                if (denominator == 0) {
-                    try self.stack.append(0);
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                .SUB => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                const result: u256 = @intCast((left + right) % denominator);
-                try self.stack.append(result);
+                    try self.stack.append(self.stack.pop() -% self.stack.pop());
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .MULMOD => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0, 1] = addition operands ; s[2] = denominator.
-                // TODO: Ditto on modulo optimisation.
-                const left: u512 = self.stack.pop();
-                const right = self.stack.pop();
-                const denominator = self.stack.pop();
-
-                if (denominator == 0) {
-                    try self.stack.append(0);
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                .DIV => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                const result: u256 = @intCast((left * right) % denominator);
-                try self.stack.append(result);
+                    // s[0] = numerator ; s[1] = denominator.
+                    const numerator = self.stack.pop();
+                    const denominator = self.stack.pop();
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .EXP => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    // Stack items are unsigned-integers, Zig will do floored division automatically.
+                    try self.stack.append(if (denominator == 0) 0 else (numerator / denominator));
 
-                // XXX: Alternative left-to-right binary exponentiation uses one less u512 but requires more bit-twiddling. Consider alternatives / optimise later on.
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .SDIV => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // s[0] = base ; s[1] = exponent.
+                    // s[0] = numerator ; s[1] = denominator.
+                    // Both values treated as 2's complement signed 256-bit integers.
+                    const numerator: i256 = @bitCast(self.stack.pop());
+                    const denominator: i256 = @bitCast(self.stack.pop());
 
-                var base: DOUBLE_WORD = self.stack.pop();
-                var exponent = self.stack.pop();
-
-                var result: DOUBLE_WORD = 1;
-
-                // Right-to-left binary exponentiation.
-                while (exponent > 0) : (exponent >>= 1) {
-                    if (@as(u1, @truncate(exponent)) == 1) {
-                        // result = (result * base) % WORD_MAX;
-                        result = @mod(result * base, WORD_MAX);
+                    if (denominator == 0) {
+                        try self.stack.append(0);
+                        continue :sw decodeOp(rom[self.pc]);
                     }
-                    // base = (base * base) % WORD_MAX;
-                    base = @mod(base * base, WORD_MAX);
-                }
 
-                // Pedantic overflow check; could use @intCast instead.
-                std.debug.assert(result <= WORD_MAX);
+                    // TODO: This can be optimised probably, look into it later. For example, before bit-casting we can perform the equivalent checks for -1 and -2^255 by checking for max u256 (i.e. all bits set, which is -1 in two's complement for i256) and whether only the first bit is set as that's maximum negative.
 
-                try self.stack.append(@as(WORD, @truncate(result)));
+                    try self.stack.append(@bitCast(if (denominator == -1 and numerator == std.math.minInt(i256)) std.math.minInt(i256) else @divTrunc(numerator, denominator)));
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SIGNEXTEND => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = byte size of target value minus one ; s[1] = value
-
-                // s[1] is read as a two's complement signed integer; if s[1] has a meaningful
-                // byte size of 2 then s[0] is given as 1 since that is s[1]'s meaningful
-                // byte size minus one.
-
-                // Practically s[0] has a maximum meaningful value of 30 when read from the
-                // stack (2 less than BYTES_IN_WORD which becomes 31, it's real
-                // meaningful-maximum, as we add 1) and if s[0] is above 31 nothing is done to
-                // s[1].
-
-                // Extension is always done up to WORD size.
-
-                const bytes = self.stack.pop() + 1;
-
-                // There's no room to extend s[1] so we can do nothing.
-                if (bytes > (BYTES_IN_WORD - 1)) {
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                .MOD => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // TODO: Optimise this as needed.
-                const value = self.stack.pop();
-                const msb = @as(u1, @truncate(value >> (u8Truncate(bytes) * 8) - 1));
+                    // s[0] = numerator ; s[1] = denominator.
+                    const numerator = self.stack.pop();
+                    const denominator = self.stack.pop();
 
-                // Not a negative two's complement number, nothing to do.
-                if (msb != 1) {
-                    try self.stack.append(value);
+                    // Stack items are unsigned-integers, Zig will do floored division automatically.
+                    try self.stack.append(if (denominator == 0) 0 else (numerator % denominator));
+
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                .SMOD => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                try self.stack.append((WORD_MAX << (u8Truncate(bytes) * 8)) | value);
+                    // s[0] = numerator ; s[1] = denominator.
+                    // Both values treated as 2's complement signed 256-bit integers.
+                    const numerator: i256 = @bitCast(self.stack.pop());
+                    const denominator: i256 = @bitCast(self.stack.pop());
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .LT => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    try self.stack.append(if (denominator == 0) 0 else @bitCast(@rem(numerator, denominator)));
 
-                // s[0] < s[1]
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .ADDMOD => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                try self.stack.append(@intFromBool(self.stack.pop() < self.stack.pop()));
+                    // s[0, 1] = addition operands ; s[2] = denominator.
+                    // TODO: Definitely a nicer way of implementing this outside of u257 and an intCast; optimise for that later.
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .GT => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    const left: u257 = self.stack.pop();
+                    const right = self.stack.pop();
+                    const denominator = self.stack.pop();
 
-                // s[0] > s[1]
+                    if (denominator == 0) {
+                        try self.stack.append(0);
+                        continue :sw decodeOp(rom[self.pc]);
+                    }
 
-                try self.stack.append(@intFromBool(self.stack.pop() > self.stack.pop()));
+                    const result: u256 = @intCast((left + right) % denominator);
+                    try self.stack.append(result);
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SLT => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .MULMOD => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // s[0] < s[1]
+                    // s[0, 1] = addition operands ; s[2] = denominator.
+                    // TODO: Ditto on modulo optimisation.
+                    const left: u512 = self.stack.pop();
+                    const right = self.stack.pop();
+                    const denominator = self.stack.pop();
 
-                // zig fmt: off
+                    if (denominator == 0) {
+                        try self.stack.append(0);
+                        continue :sw decodeOp(rom[self.pc]);
+                    }
+
+                    const result: u256 = @intCast((left * right) % denominator);
+                    try self.stack.append(result);
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .EXP => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // XXX: Alternative left-to-right binary exponentiation uses one less u512 but requires more bit-twiddling. Consider alternatives / optimise later on.
+
+                    // s[0] = base ; s[1] = exponent.
+
+                    var base: DOUBLE_WORD = self.stack.pop();
+                    var exponent = self.stack.pop();
+
+                    var result: DOUBLE_WORD = 1;
+
+                    // Right-to-left binary exponentiation.
+                    while (exponent > 0) : (exponent >>= 1) {
+                        if (@as(u1, @truncate(exponent)) == 1) {
+                            // result = (result * base) % WORD_MAX;
+                            result = @mod(result * base, WORD_MAX);
+                        }
+                        // base = (base * base) % WORD_MAX;
+                        base = @mod(base * base, WORD_MAX);
+                    }
+
+                    // Pedantic overflow check; could use @intCast instead.
+                    std.debug.assert(result <= WORD_MAX);
+
+                    try self.stack.append(@as(WORD, @truncate(result)));
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .SIGNEXTEND => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // s[0] = byte size of target value minus one ; s[1] = value
+
+                    // s[1] is read as a two's complement signed integer; if s[1] has a meaningful
+                    // byte size of 2 then s[0] is given as 1 since that is s[1]'s meaningful
+                    // byte size minus one.
+
+                    // Practically s[0] has a maximum meaningful value of 30 when read from the
+                    // stack (2 less than BYTES_IN_WORD which becomes 31, it's real
+                    // meaningful-maximum, as we add 1) and if s[0] is above 31 nothing is done to
+                    // s[1].
+
+                    // Extension is always done up to WORD size.
+
+                    const bytes = self.stack.pop() + 1;
+
+                    // There's no room to extend s[1] so we can do nothing.
+                    if (bytes > (BYTES_IN_WORD - 1)) {
+                        continue :sw decodeOp(rom[self.pc]);
+                    }
+
+                    // TODO: Optimise this as needed.
+                    const value = self.stack.pop();
+                    const msb = @as(u1, @truncate(value >> (u8Truncate(bytes) * 8) - 1));
+
+                    // Not a negative two's complement number, nothing to do.
+                    if (msb != 1) {
+                        try self.stack.append(value);
+                        continue :sw decodeOp(rom[self.pc]);
+                    }
+
+                    try self.stack.append((WORD_MAX << (u8Truncate(bytes) * 8)) | value);
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .LT => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // s[0] < s[1]
+
+                    try self.stack.append(@intFromBool(self.stack.pop() < self.stack.pop()));
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .GT => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // s[0] > s[1]
+
+                    try self.stack.append(@intFromBool(self.stack.pop() > self.stack.pop()));
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .SLT => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // s[0] < s[1]
+
+                    // zig fmt: off
                 try self.stack.append(@intFromBool(
                     @as(SIGNED_WORD, @bitCast(self.stack.pop()))
                         <
                     @as(SIGNED_WORD, @bitCast(self.stack.pop()))));
                 // zig fmt: on
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SGT => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .SGT => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // s[0] > s[1]
+                    // s[0] > s[1]
 
-                // zig fmt: off
+                    // zig fmt: off
                 try self.stack.append(@intFromBool(
                     @as(SIGNED_WORD, @bitCast(self.stack.pop()))
                         >
                     @as(SIGNED_WORD, @bitCast(self.stack.pop()))));
                 // zig fmt: on
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .EQ => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .EQ => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // s[0] == s[1]
+                    // s[0] == s[1]
 
-                try self.stack.append(@intFromBool(self.stack.pop() == self.stack.pop()));
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .ISZERO => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] == 0
-
-                try self.stack.append(@intFromBool(self.stack.pop() == 0));
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .AND => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // Bitwise: s[0] AND s[1]
-
-                // TODO: A bunch of these kinds of patterns can likely be optimised to just popping one element off, and then setting the top stack element. Optimise after BoundedArray is kept or changed.
-                try self.stack.append(self.stack.pop() & self.stack.pop());
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .OR => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // Bitwise: s[0] OR s[1]
-
-                try self.stack.append(self.stack.pop() | self.stack.pop());
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .XOR => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // Bitwise: s[0] XOR s[1]
-
-                try self.stack.append(self.stack.pop() ^ self.stack.pop());
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .NOT => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // Bitwise: NOT s[0]
-
-                try self.stack.append(~self.stack.pop());
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .BYTE => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = byte offset to take from ; s[1] = word value to be sliced
-
-                const offset = self.stack.pop();
-
-                // s[0] above amount of bytes in WORD, shortcut response to 0.
-                if (offset >= BYTES_IN_WORD) {
-                    self.stack.set(self.stack.len - 1, 0);
+                    try self.stack.append(@intFromBool(self.stack.pop() == self.stack.pop()));
 
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                .ISZERO => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // zig fmt: off
+                    // s[0] == 0
+
+                    try self.stack.append(@intFromBool(self.stack.pop() == 0));
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .AND => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // Bitwise: s[0] AND s[1]
+
+                    // TODO: A bunch of these kinds of patterns can likely be optimised to just popping one element off, and then setting the top stack element. Optimise after BoundedArray is kept or changed.
+                    try self.stack.append(self.stack.pop() & self.stack.pop());
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .OR => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // Bitwise: s[0] OR s[1]
+
+                    try self.stack.append(self.stack.pop() | self.stack.pop());
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .XOR => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // Bitwise: s[0] XOR s[1]
+
+                    try self.stack.append(self.stack.pop() ^ self.stack.pop());
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .NOT => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // Bitwise: NOT s[0]
+
+                    try self.stack.append(~self.stack.pop());
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .BYTE => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // s[0] = byte offset to take from ; s[1] = word value to be sliced
+
+                    const offset = self.stack.pop();
+
+                    // s[0] above amount of bytes in WORD, shortcut response to 0.
+                    if (offset >= BYTES_IN_WORD) {
+                        self.stack.set(self.stack.len - 1, 0);
+
+                        continue :sw decodeOp(rom[self.pc]);
+                    }
+
+                    // zig fmt: off
                 self.stack.set(
                     self.stack.len - 1,
                     u8Truncate(
@@ -435,127 +438,135 @@ pub const EVM = struct {
                 );
                 // zig fmt: on
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            // XXX: For SHL, SHR, SAR: which is faster doing these bitwise shifts or equivalent arithmetic (floor division etc). Optimisation. Need to benchmark the assembly from these and compare it to the "naive" way of doing them (just divisions etc) since LLVM _probably_ does a better job..?
-            .SHL => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = bits to shift by ; s[1] = value to be shifted
-
-                const bits = self.stack.pop();
-
-                // Trying to shift left over 255 (WORD bits - 1) places shortcut to zero.
-                if (bits >= @typeInfo(WORD).int.bits) {
-                    _ = self.stack.pop(); // XXX: Ripe for top of stack set.
-                    try self.stack.append(0);
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                // XXX: For SHL, SHR, SAR: which is faster doing these bitwise shifts or equivalent arithmetic (floor division etc). Optimisation. Need to benchmark the assembly from these and compare it to the "naive" way of doing them (just divisions etc) since LLVM _probably_ does a better job..?
+                .SHL => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                // TODO: u8 being log2(u256) i.e. log2(WORD) is all the reflection on WORD worth it? Idea being maybe someone could (idk why) change WORD to.. u128 but then it wouldn't be the EVM (unless the spec changed) etc.
-                try self.stack.append(self.stack.pop() << @as(u8, @truncate(bits)));
+                    // s[0] = bits to shift by ; s[1] = value to be shifted
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SHR => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    const bits = self.stack.pop();
 
-                // s[0] = bits to shift by ; s[1] = value to be shifted
-
-                const bits = self.stack.pop();
-
-                // Trying to shift right over 255 (WORD bits - 1) places shortcut to zero.
-                if (bits >= @typeInfo(WORD).int.bits) {
-                    _ = self.stack.pop();
-                    try self.stack.append(0);
-                    continue :sw decodeOp(rom[self.pc]);
-                }
-
-                try self.stack.append(self.stack.pop() >> @as(u8, @truncate(bits)));
-
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .SAR => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
-
-                // s[0] = bits to shift by ; s[1] = value to be shifted
-                // s[1] and result pushed to stack are treated as signed; s[0] is unsigned.
-
-                const bits = self.stack.pop();
-                const value = asSignedWord(self.stack.pop());
-
-                // Trying to shift right over 255 (WORD bits - 1) places shortcut...
-                if (bits >= @typeInfo(WORD).int.bits) {
-                    switch (value > 0) {
-                        // ...positive so 0
-                        true => try self.stack.append(0),
-                        // ...negative so -1
-                        false => try self.stack.append(asUnsignedWord(-1)),
+                    // Trying to shift left over 255 (WORD bits - 1) places shortcut to zero.
+                    if (bits >= @typeInfo(WORD).int.bits) {
+                        _ = self.stack.pop(); // XXX: Ripe for top of stack set.
+                        try self.stack.append(0);
+                        continue :sw decodeOp(rom[self.pc]);
                     }
 
+                    // TODO: u8 being log2(u256) i.e. log2(WORD) is all the reflection on WORD worth it? Idea being maybe someone could (idk why) change WORD to.. u128 but then it wouldn't be the EVM (unless the spec changed) etc.
+                    try self.stack.append(self.stack.pop() << @as(u8, @truncate(bits)));
+
                     continue :sw decodeOp(rom[self.pc]);
-                }
+                },
+                .SHR => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
 
-                try self.stack.append(asUnsignedWord(value >> @as(u8, @truncate(bits))));
+                    // s[0] = bits to shift by ; s[1] = value to be shifted
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            .KECCAK256 => {
-                // TODO: Check zig stdlib or other packages. Also since this isn't a zkEVM make sure any side-channel proections are disabled for any calls to hash.
-            },
-            //
-            // TODO: From op ADDRESS onwards
-            //
-            .PUSH0 => |op| {
-                traceOp(op, self.pc, .endln);
-                self.pc += 1;
+                    const bits = self.stack.pop();
 
-                try self.stack.append(0);
+                    // Trying to shift right over 255 (WORD bits - 1) places shortcut to zero.
+                    if (bits >= @typeInfo(WORD).int.bits) {
+                        _ = self.stack.pop();
+                        try self.stack.append(0);
+                        continue :sw decodeOp(rom[self.pc]);
+                    }
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            // TODO: I don't think ranges over enums are allowed here, can check later (simple example file elsewhere) not that important right now. It is funny that I end up unrolling this manually though.
-            // zig fmt: off
+                    try self.stack.append(self.stack.pop() >> @as(u8, @truncate(bits)));
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .SAR => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    // s[0] = bits to shift by ; s[1] = value to be shifted
+                    // s[1] and result pushed to stack are treated as signed; s[0] is unsigned.
+
+                    const bits = self.stack.pop();
+                    const value = asSignedWord(self.stack.pop());
+
+                    // Trying to shift right over 255 (WORD bits - 1) places shortcut...
+                    if (bits >= @typeInfo(WORD).int.bits) {
+                        switch (value > 0) {
+                            // ...positive so 0
+                            true => try self.stack.append(0),
+                            // ...negative so -1
+                            false => try self.stack.append(asUnsignedWord(-1)),
+                        }
+
+                        continue :sw decodeOp(rom[self.pc]);
+                    }
+
+                    try self.stack.append(asUnsignedWord(value >> @as(u8, @truncate(bits))));
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                .KECCAK256 => {
+                    // TODO: Check zig stdlib or other packages. Also since this isn't a zkEVM make sure any side-channel proections are disabled for any calls to hash.
+                },
+                //
+                // TODO: From op ORIGIN onwards
+                //
+                .ADDRESS => {},
+                .BALANCE => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+                    // in-place replace the content of the balance
+                    self.stack.set(self.stack.len - 1, try self.env.getBalance(self.stack.get(self.stack.len - 1)));
+                },
+                .PUSH0 => |op| {
+                    traceOp(op, self.pc, .endln);
+                    self.pc += 1;
+
+                    try self.stack.append(0);
+
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                // TODO: I don't think ranges over enums are allowed here, can check later (simple example file elsewhere) not that important right now. It is funny that I end up unrolling this manually though.
+                // zig fmt: off
             inline .PUSH1,  .PUSH2,  .PUSH3,  .PUSH4,  .PUSH5,  .PUSH6,  .PUSH7,  .PUSH8,
                    .PUSH9,  .PUSH10, .PUSH11, .PUSH12, .PUSH13, .PUSH14, .PUSH15, .PUSH16,
                    .PUSH17, .PUSH18, .PUSH19, .PUSH20, .PUSH21, .PUSH22, .PUSH23, .PUSH24,
                    .PUSH25, .PUSH26, .PUSH27, .PUSH28, .PUSH29, .PUSH30, .PUSH31, .PUSH32
             // zig fmt: on
-            => |op| {
-                traceOp(op, self.pc, .cntln);
-                self.pc += 1;
+                => |op| {
+                    traceOp(op, self.pc, .cntln);
+                    self.pc += 1;
 
-                // Offset vs PUSH0 is amount of bytes to read forward and push onto stack as
-                // this instructions operand.
-                const offset = @intFromEnum(op) - @intFromEnum(OpCode.PUSH0);
+                    // Offset vs PUSH0 is amount of bytes to read forward and push onto stack as
+                    // this instructions operand.
+                    const offset = @intFromEnum(op) - @intFromEnum(OpCode.PUSH0);
 
-                const operand_bytes = rom[self.pc..][0..offset];
+                    const operand_bytes = rom[self.pc..][0..offset];
 
-                // std.mem.readInt does not 0-pad types less than requested size, so we construct and reify the `type` we need then upcast to WORD.
-                const operand = @as(WORD, std.mem.readInt(
-                    @Type(.{ .int = .{
-                        .signedness = .unsigned,
-                        .bits = 8 * operand_bytes.len,
-                    } }),
-                    operand_bytes,
-                    .big,
-                ));
+                    // std.mem.readInt does not 0-pad types less than requested size, so we construct and reify the `type` we need then upcast to WORD.
+                    const operand = @as(WORD, std.mem.readInt(
+                        @Type(.{ .int = .{
+                            .signedness = .unsigned,
+                            .bits = 8 * operand_bytes.len,
+                        } }),
+                        operand_bytes,
+                        .big,
+                    ));
 
-                traceOpPush(self.pc + offset, operand);
+                    traceOpPush(self.pc + offset, operand);
 
-                try self.stack.append(operand);
-                self.pc += offset;
+                    try self.stack.append(operand);
+                    self.pc += offset;
 
-                continue :sw decodeOp(rom[self.pc]);
-            },
-            // TEMPORARY.
-            // TODO: Do we want catch unreachable here (in which case make OpCode enum non-exhaustive) or do we want a prong to prevent runtime crashes and log the unhandled opcode. I guess the latter.
-            else => {
-                return error.UnknownType;
-            },
-        };
-    }
-};
+                    continue :sw decodeOp(rom[self.pc]);
+                },
+                // TEMPORARY.
+                // TODO: Do we want catch unreachable here (in which case make OpCode enum non-exhaustive) or do we want a prong to prevent runtime crashes and log the unhandled opcode. I guess the latter.
+                else => {
+                    return error.UnknownType;
+                },
+            };
+        }
+    };
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,11 +1,13 @@
 const std = @import("std");
+const util = @import("util.zig");
 const print = std.debug.print;
 const EnumField = std.builtin.Type.EnumField;
 const fmt = std.fmt;
-
-const EVM = @import("evm.zig").EVM;
+const DummyEnv = util.DummyEnv;
+const EVM = util.EVM;
 
 pub fn main() !void {
-    var evm2 = try EVM.init();
+    var dummyEnv = DummyEnv{};
+    var evm2 = try EVM.init(&dummyEnv);
     try evm2.execute(&.{ 0x5F, 0x60, 0x11, 0x61, 0x22, 0x33, 0x00 });
 }

--- a/src/util.zig
+++ b/src/util.zig
@@ -1,5 +1,12 @@
 const std = @import("std");
-const EVM = @import("evm.zig").EVM;
+const NewEVM = @import("evm.zig").NewEVM;
+
+pub const DummyEnv = struct {
+    pub fn getBalance(_: *DummyEnv, _: u256) !u256 {
+        return 0;
+    }
+};
+pub const EVM = NewEVM(DummyEnv);
 
 // TODO: Place elsewhere, idk.
 // Inspired by: https://github.com/jsign/phant/blob/18eeadffd24de9c6b3ae5c7505ada52c43f2b1d4/src/common/hexutils.zig#L73
@@ -12,7 +19,8 @@ pub inline fn htb(comptime bytes: []const u8) [bytes.len / 2]u8 {
 // TODO: Replace this with test files on-disk which are read to execute EVM instructions and then the unit test in Zig code is about asserting expected values; or do it all in-code but in any case abstract creation of EVM.
 // TODO: Probably also want some re-usable one to avoid re-allocating every single time in these unit tests? But fresh context is important, but also testing properly is important.
 pub fn evmBasicBytecode(comptime bytes: []const u8) !EVM {
-    var evm = try EVM.init();
+    var dummyEnv: DummyEnv = .{};
+    var evm = try EVM.init(&dummyEnv);
     try evm.execute(&htb(bytes));
 
     return evm;


### PR DESCRIPTION
This is a proposed interface for integration into phant, and it can be used to implement basic interaction methods between the EVM and the environment (`BALANCE`, `ORIGIN`, etc...)

The approach taken is to use a given type, which can then be instantiated depending on what the environment is (stateless, stateful, and "dummy" for tests).

I also implemented a no-op dummy environment for testing.

This PR comes with no tests, as it's meant to kickstart a discussion at this stage. But I can add them afterwards (the only difference is that the `BALANCE` opcode would have to be tested, so it's not too much work either).