### PR TITLE
interface: BALANCE does not take any argument

### DIFF
--- a/src/lib/DummyEnv.zig
+++ b/src/lib/DummyEnv.zig
@@ -12,6 +12,6 @@ pub fn init(block: types.BlockHeader) DummyEnv {
     return .{ .block = block };
 }
 
-pub fn getBalance(_: *DummyEnv, _: u256) !u256 {
+pub fn getBalance(_: *DummyEnv) !u256 {
     return 0;
 }

--- a/src/lib/evm.zig
+++ b/src/lib/evm.zig
@@ -579,8 +579,7 @@ pub fn New(comptime Environment: type) type {
                 .BALANCE => |op| {
                     traceOp(op, self.pc, .endln);
 
-                    // in-place replace the content of the balance
-                    self.stack.set(self.stack.len - 1, try self.env.getBalance(self.stack.get(self.stack.len - 1)));
+                    try self.stack.append(try self.env.getBalance());
                 },
                 // TODO: Spit as appropriate when implementing.
                 .ORIGIN, .CALLER, .CALLVALUE, .CALLDATALOAD, .CALLDATASIZE, .CALLDATACOPY, .CODESIZE, .CODECOPY, .GASPRICE, .EXTCODESIZE, .EXTCODECOPY, .RETURNDATASIZE, .RETURNDATACOPY, .EXTCODEHASH => {


### PR DESCRIPTION
BALANCE is only available for the current contract, so it doesn't take any argument. In fact, it is now called `SELFBALANCE` in the yellow paper.