### PR TITLE
disable Tracy by default

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -6,11 +6,12 @@ const print = std.debug.print;
 const zevem = @import("zevem");
 const EVM = zevem.EVM;
 
-const tracy = @import("tracy");
+const config = zevem.config;
+const tracy = if (config.use_tracy) @import("tracy") else struct {};
 
 pub fn main() !void {
-    const zone = tracy.initZone(@src(), .{ .name = "cli main" });
-    defer zone.deinit();
+    const zone = if (config.use_tracy) tracy.initZone(@src(), .{ .name = "cli main" });
+    defer if (config.use_tracy) zone.deinit();
     print("Hello, command-line world!\n", .{});
 
     var gpa: std.heap.DebugAllocator(.{}) = .init;

--- a/src/root.zig
+++ b/src/root.zig
@@ -7,6 +7,7 @@ pub const evm = @import("lib/evm.zig");
 pub const DummyEnv = @import("lib/DummyEnv.zig");
 
 pub const EVM = evm.New(DummyEnv);
+pub const config = @import("config");
 
 // TODO: Since moving stackOffTop into utils the imports (like this one) feel a bit messy? Clean up later?
 const types = @import("lib/types.zig");


### PR DESCRIPTION
Tracy is causing issues when zevem is built as a client library for targets with poor libc support (anything freestanding). This change makes sure that it is disabled by default, and no modules are referencing the C++ code when it's not being compiled in.