### PR TITLE
Add execution-spec-tests state test harness (zig build spec)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ zig-global/
 
 # Zig artifacts while not using dnf for whatever reason.
 .jam/zig-*.tar.*
+
+# Downloaded execution-spec-tests fixture releases (see `just fetch-fixtures`).
+spec/fixtures/

--- a/build.zig
+++ b/build.zig
@@ -53,6 +53,35 @@ pub fn build(b: *std.Build) !void {
     const run_test_cmd = b.addRunArtifact(lib_test);
     test_step.dependOn(&run_test_cmd.step);
 
+    // Specification test harness: consumes execution-spec-tests fixtures with
+    // zevem as the EVM (see spec/README.org).
+    const spec_mod = b.createModule(.{
+        .root_source_file = b.path("spec/src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    spec_mod.addImport("zevem", lib_mod);
+
+    const spec_exe = b.addExecutable(.{
+        .name = "zevem-spec",
+        .root_module = spec_mod,
+    });
+    b.installArtifact(spec_exe);
+
+    const run_spec = b.addRunArtifact(spec_exe);
+    if (b.args) |args| run_spec.addArgs(args);
+
+    const spec_step = b.step("spec", "Consume execution-spec-tests fixtures (args after --)");
+    spec_step.dependOn(&run_spec.step);
+
+    // Harness unit and vendored-fixture tests join `zig build test`.
+    const spec_test = b.addTest(.{
+        .root_module = spec_mod,
+        .filters = test_filters,
+    });
+    const run_spec_test_cmd = b.addRunArtifact(spec_test);
+    test_step.dependOn(&run_spec_test_cmd.step);
+
     var tracy: *std.Build.Dependency = undefined;
     if (want_tracy) {
         tracy = b.dependency("tracy", .{

--- a/justfile
+++ b/justfile
@@ -55,6 +55,18 @@ test-all: test-debug
 # test-all: (test 'off') (test 'fast') (test 'safe')
 #    # @echo "DONE"
 
+# Download the pinned execution-spec-tests fixture release (state tests only,
+# ~500 MB extracted) into spec/fixtures. See spec/README.org.
+[group: 'spec']
+fetch-fixtures version='v5.4.0':
+    mkdir -p spec/fixtures/{{version}}
+    curl -L https://github.com/ethereum/execution-spec-tests/releases/download/{{version}}/fixtures_stable.tar.gz | tar -xz -C spec/fixtures/{{version}} fixtures/state_tests
+
+# Consume fixtures with the spec harness, e.g.: just spec spec/fixtures/v5.4.0/fixtures/state_tests
+[group: 'spec']
+spec *ARGS:
+    zig build spec --release=fast -- {{ARGS}}
+
 # XXX: Temporary until Zig's fuse-overlayfs d_type woes are sorted.
 [private]
 dt-build *EXTRA_FLAGS:

--- a/spec/README.org
+++ b/spec/README.org
@@ -1,0 +1,57 @@
+#+TITLE: zevem spec harness
+
+Consumes official [[https://github.com/ethereum/execution-spec-tests][execution-spec-tests]] (EEST) state test fixtures with zevem as the EVM, so zevem runs against real test data instead of only hand-written unit tests.
+
+** Quickstart
+
+#+begin_src sh
+just fetch-fixtures                                  # download the pinned release (state tests only)
+just spec spec/fixtures/v5.4.0/fixtures/state_tests  # consume everything, print the scoreboard
+#+end_src
+
+Useful flags (see ~zig build spec -- --help~ style usage in [[./src/main.zig][main.zig]]): ~--fork=NAME~ (default Cancun), ~--verbose~, ~--max=N~, ~--strict~ (non-zero exit on failure, for CI), ~--evm-trace~ (keep zevem's per-opcode stderr tracing, which is otherwise silenced).
+
+** How it works
+
+A state test fixture declares a pre state, an environment, a transaction, and the expected post state. zevem is /just/ the EVM, so the harness acts as its host:
+
+1. [[./src/fixture.zig][fixture.zig]] parses the fixture JSON (pre/env/transaction vectors/post).
+2. [[./src/state.zig][state.zig]] holds the world state σ: a flat account map with storage.
+3. [[./src/runner.zig][runner.zig]] applies the state transition around EVM execution (YP section 6, Cancun rules): validation, intrinsic gas, nonce and gas purchase, value transfer or contract creation, zevem execution, refunds, priority fee, EIP-161 cleanup.
+4. The post state is verified twice: account-by-account against the fixture's ~post.state~ (precise diffs for debugging), and via the state root against ~post.hash~ using [[./src/trie.zig][trie.zig]] (secure Merkle Patricia Trie over RLP-encoded accounts, [[./src/rlp.zig][rlp.zig]]).
+
+Every entry ends as exactly one of:
+
+- pass :: executed and the post state (accounts and root) matched.
+- pass (rejected) :: the transaction was invalid, the fixture expected that, and the untouched state matched.
+- fail :: a real disagreement, printed with a per-account diff. These are the interesting ones.
+- skip :: something zevem or the harness cannot faithfully execute yet, counted per reason (opcode not implemented, needs CREATE/CALL orchestration, precompile target, blob/set-code transaction, fixture expects logs). Never silently dropped.
+
+** Current scoreboard
+
+Fixture release v5.4.0, fork Cancun, all ~state_tests~ (16,847 Cancun entries of 44,039 total):
+
+#+begin_example
+pass:            846
+pass (rejected): 372
+fail:            69
+skip:            15560
+  tx_type_unsupported: 898
+  evm_unimplemented: 14461
+  evm_orchestrate: 157
+  precompile_unsupported: 20
+  logs_uncollected: 24
+#+end_example
+
+The skip counts double as a progress tracker: implementing an opcode family moves its entries from skip into pass/fail, and the fails come with account-level diffs to debug against.
+
+** Vendored fixtures
+
+[[./src/testdata/][src/testdata/]] holds a handful of test cases extracted verbatim from the pinned release (the source file is named inside each) which zevem executes fully today. They run as part of ~zig build test~ and must always pass; they cover the execution path (stack underflow halts), the validation path (access list intrinsic gas, both accepted and rejected), and therefore also RLP, trie, and state transition correctness end to end.
+
+** Known approximations
+
+- Cancun rules only; post entries for other forks are skipped (run older forks at your own risk via ~--fork~, the transition rules the harness applies stay Cancun's).
+- The gas refund counter is always zero (zevem has no SSTORE/SELFDESTRUCT yet, so nothing can produce refunds).
+- EIP-161 touched-account cleanup only considers the accounts the harness itself can touch (sender, target, coinbase); once inner calls exist this needs the full touched set.
+- ~DummyEnv.getBalance~ returns zero, so BALANCE-dependent tests fail with honest diffs rather than passing by luck. The harness drives ~DummyEnv~ directly because ~evm.New~ is currently only instantiable with it (op.zig's dynamic gas function pointers are typed against ~New(DummyEnv)~).

--- a/spec/src/fixture.zig
+++ b/spec/src/fixture.zig
@@ -1,0 +1,416 @@
+//! Parser for execution-spec-tests (EEST) state test fixtures.
+//!
+//! Fixture format reference:
+//! https://eest.ethereum.org/main/consuming_tests/state_test/
+//!
+//! A fixture file is a JSON object of test name to test case. Each test case
+//! holds a single pre state and environment plus vectors of transaction
+//! parameters (data, gasLimit, value); each post entry selects one combination
+//! of those vectors via `indexes` and declares the expected outcome.
+
+const std = @import("std");
+
+pub const Address = u160;
+
+pub const ParseError = error{
+    MalformedFixture,
+    MalformedHex,
+} || std.mem.Allocator.Error;
+
+pub const Env = struct {
+    coinbase: Address,
+    gas_limit: u64,
+    number: u64,
+    timestamp: u64,
+    base_fee: u64,
+    random: [32]u8,
+};
+
+pub const StorageSlot = struct {
+    key: u256,
+    value: u256,
+};
+
+pub const Account = struct {
+    address: Address,
+    nonce: u64,
+    balance: u256,
+    code: []const u8,
+    storage: []const StorageSlot,
+};
+
+pub const AccessListEntry = struct {
+    address: Address,
+    storage_keys: []const u256,
+};
+
+pub const Transaction = struct {
+    nonce: u64,
+    sender: Address,
+    /// null is contract creation (fixture `to` of "").
+    to: ?Address,
+    gas_price: ?u256,
+    max_fee_per_gas: ?u256,
+    max_priority_fee_per_gas: ?u256,
+    gas_limits: []const u256,
+    values: []const u256,
+    datas: []const []const u8,
+    /// One access list per data vector entry, if present.
+    access_lists: ?[]const []const AccessListEntry,
+    /// Transaction features the harness does not execute; presence downgrades
+    /// the test to a skip rather than a parse failure.
+    has_blobs: bool,
+    has_authorizations: bool,
+};
+
+pub const PostEntry = struct {
+    hash: [32]u8,
+    logs_hash: [32]u8,
+    data_index: usize,
+    gas_index: usize,
+    value_index: usize,
+    expect_exception: ?[]const u8,
+    state: []const Account,
+};
+
+pub const ForkPost = struct {
+    fork: []const u8,
+    entries: []const PostEntry,
+};
+
+pub const TestCase = struct {
+    name: []const u8,
+    env: Env,
+    pre: []const Account,
+    transaction: Transaction,
+    posts: []const ForkPost,
+    chain_id: u64,
+};
+
+/// Parse every test case in a fixture file's contents. All results are
+/// allocated in `alloc`, which is assumed to be an arena.
+pub fn parseSlice(alloc: std.mem.Allocator, bytes: []const u8) ParseError![]TestCase {
+    const value = std.json.parseFromSliceLeaky(std.json.Value, alloc, bytes, .{}) catch
+        return error.MalformedFixture;
+
+    const tests = objectOf(value) orelse return error.MalformedFixture;
+
+    var cases = std.ArrayListUnmanaged(TestCase).empty;
+
+    var it = tests.iterator();
+    while (it.next()) |kv| {
+        const case = objectOf(kv.value_ptr.*) orelse return error.MalformedFixture;
+        try cases.append(alloc, .{
+            .name = kv.key_ptr.*,
+            .env = try parseEnv(case.get("env") orelse return error.MalformedFixture),
+            .pre = try parseAccounts(alloc, case.get("pre") orelse return error.MalformedFixture),
+            .transaction = try parseTransaction(alloc, case.get("transaction") orelse return error.MalformedFixture),
+            .posts = try parsePosts(alloc, case.get("post") orelse return error.MalformedFixture),
+            .chain_id = try parseChainId(case.get("config")),
+        });
+    }
+
+    return cases.items;
+}
+
+fn parseEnv(value: std.json.Value) ParseError!Env {
+    const env = objectOf(value) orelse return error.MalformedFixture;
+
+    return .{
+        .coinbase = try hexIntField(env, "currentCoinbase", Address),
+        .gas_limit = try hexIntField(env, "currentGasLimit", u64),
+        .number = try hexIntField(env, "currentNumber", u64),
+        .timestamp = try hexIntField(env, "currentTimestamp", u64),
+        // Frontier-filled fixtures predate EIP-1559 and omit the base fee.
+        .base_fee = if (env.get("currentBaseFee")) |fee| try hexInt(fee, u64) else 0,
+        .random = if (env.get("currentRandom")) |random| try hexHash(random) else [_]u8{0} ** 32,
+    };
+}
+
+fn parseAccounts(alloc: std.mem.Allocator, value: std.json.Value) ParseError![]Account {
+    const accounts = objectOf(value) orelse return error.MalformedFixture;
+
+    var out = std.ArrayListUnmanaged(Account).empty;
+
+    var it = accounts.iterator();
+    while (it.next()) |kv| {
+        const account = objectOf(kv.value_ptr.*) orelse return error.MalformedFixture;
+
+        var slots = std.ArrayListUnmanaged(StorageSlot).empty;
+        if (account.get("storage")) |storage_value| {
+            const storage = objectOf(storage_value) orelse return error.MalformedFixture;
+            var slot_it = storage.iterator();
+            while (slot_it.next()) |slot| {
+                try slots.append(alloc, .{
+                    .key = try hexIntString(slot.key_ptr.*, u256),
+                    .value = try hexInt(slot.value_ptr.*, u256),
+                });
+            }
+        }
+
+        try out.append(alloc, .{
+            .address = try hexIntString(kv.key_ptr.*, Address),
+            .nonce = try hexIntField(account, "nonce", u64),
+            .balance = try hexIntField(account, "balance", u256),
+            .code = try hexBytesField(alloc, account, "code"),
+            .storage = slots.items,
+        });
+    }
+
+    return out.items;
+}
+
+fn parseTransaction(alloc: std.mem.Allocator, value: std.json.Value) ParseError!Transaction {
+    const tx = objectOf(value) orelse return error.MalformedFixture;
+
+    const to_string = stringOf(tx.get("to") orelse return error.MalformedFixture) orelse
+        return error.MalformedFixture;
+
+    return .{
+        .nonce = try hexIntField(tx, "nonce", u64),
+        .sender = try hexIntField(tx, "sender", Address),
+        .to = if (to_string.len == 0) null else try hexIntString(to_string, Address),
+        .gas_price = if (tx.get("gasPrice")) |price| try hexInt(price, u256) else null,
+        .max_fee_per_gas = if (tx.get("maxFeePerGas")) |fee| try hexInt(fee, u256) else null,
+        .max_priority_fee_per_gas = if (tx.get("maxPriorityFeePerGas")) |fee| try hexInt(fee, u256) else null,
+        .gas_limits = try hexIntArray(alloc, tx.get("gasLimit") orelse return error.MalformedFixture, u256),
+        .values = try hexIntArray(alloc, tx.get("value") orelse return error.MalformedFixture, u256),
+        .datas = try hexBytesArray(alloc, tx.get("data") orelse return error.MalformedFixture),
+        .access_lists = if (tx.get("accessLists")) |lists| try parseAccessLists(alloc, lists) else null,
+        .has_blobs = tx.get("blobVersionedHashes") != null or tx.get("maxFeePerBlobGas") != null,
+        .has_authorizations = tx.get("authorizationList") != null,
+    };
+}
+
+fn parseAccessLists(alloc: std.mem.Allocator, value: std.json.Value) ParseError![]const []const AccessListEntry {
+    const lists = arrayOf(value) orelse return error.MalformedFixture;
+
+    var out = std.ArrayListUnmanaged([]const AccessListEntry).empty;
+
+    for (lists.items) |list_value| {
+        // A null entry means "no access list" for that data index (legacy tx).
+        if (list_value == .null) {
+            try out.append(alloc, &.{});
+            continue;
+        }
+
+        const list = arrayOf(list_value) orelse return error.MalformedFixture;
+
+        var entries = std.ArrayListUnmanaged(AccessListEntry).empty;
+        for (list.items) |entry_value| {
+            const entry = objectOf(entry_value) orelse return error.MalformedFixture;
+
+            var keys = std.ArrayListUnmanaged(u256).empty;
+            const storage_keys = arrayOf(entry.get("storageKeys") orelse return error.MalformedFixture) orelse
+                return error.MalformedFixture;
+            for (storage_keys.items) |key| try keys.append(alloc, try hexInt(key, u256));
+
+            try entries.append(alloc, .{
+                .address = try hexIntField(entry, "address", Address),
+                .storage_keys = keys.items,
+            });
+        }
+
+        try out.append(alloc, entries.items);
+    }
+
+    return out.items;
+}
+
+fn parsePosts(alloc: std.mem.Allocator, value: std.json.Value) ParseError![]ForkPost {
+    const posts = objectOf(value) orelse return error.MalformedFixture;
+
+    var out = std.ArrayListUnmanaged(ForkPost).empty;
+
+    var it = posts.iterator();
+    while (it.next()) |kv| {
+        const entries_value = arrayOf(kv.value_ptr.*) orelse return error.MalformedFixture;
+
+        var entries = std.ArrayListUnmanaged(PostEntry).empty;
+        for (entries_value.items) |entry_value| {
+            const entry = objectOf(entry_value) orelse return error.MalformedFixture;
+            const indexes = objectOf(entry.get("indexes") orelse return error.MalformedFixture) orelse
+                return error.MalformedFixture;
+
+            try entries.append(alloc, .{
+                .hash = try hexHash(entry.get("hash") orelse return error.MalformedFixture),
+                .logs_hash = try hexHash(entry.get("logs") orelse return error.MalformedFixture),
+                .data_index = try indexField(indexes, "data"),
+                .gas_index = try indexField(indexes, "gas"),
+                .value_index = try indexField(indexes, "value"),
+                .expect_exception = if (entry.get("expectException")) |exception|
+                    stringOf(exception) orelse return error.MalformedFixture
+                else
+                    null,
+                .state = try parseAccounts(alloc, entry.get("state") orelse return error.MalformedFixture),
+            });
+        }
+
+        try out.append(alloc, .{ .fork = kv.key_ptr.*, .entries = entries.items });
+    }
+
+    return out.items;
+}
+
+fn parseChainId(value: ?std.json.Value) ParseError!u64 {
+    const config = objectOf(value orelse return 1) orelse return error.MalformedFixture;
+    const chain_id = config.get("chainid") orelse return 1;
+    return hexInt(chain_id, u64);
+}
+
+// ////////////////////////////////////////////////////////////////////////////
+// //////////////// JSON value navigation and hex parsing.
+
+fn objectOf(value: std.json.Value) ?std.json.ObjectMap {
+    return switch (value) {
+        .object => |object| object,
+        else => null,
+    };
+}
+
+fn arrayOf(value: std.json.Value) ?std.json.Array {
+    return switch (value) {
+        .array => |array| array,
+        else => null,
+    };
+}
+
+fn stringOf(value: std.json.Value) ?[]const u8 {
+    return switch (value) {
+        .string => |string| string,
+        else => null,
+    };
+}
+
+fn stripHexPrefix(string: []const u8) []const u8 {
+    return if (std.mem.startsWith(u8, string, "0x")) string[2..] else string;
+}
+
+fn hexIntString(string: []const u8, comptime T: type) ParseError!T {
+    const digits = stripHexPrefix(string);
+    if (digits.len == 0) return 0;
+    return std.fmt.parseInt(T, digits, 16) catch error.MalformedHex;
+}
+
+fn hexInt(value: std.json.Value, comptime T: type) ParseError!T {
+    return hexIntString(stringOf(value) orelse return error.MalformedFixture, T);
+}
+
+fn hexIntField(object: std.json.ObjectMap, field: []const u8, comptime T: type) ParseError!T {
+    return hexInt(object.get(field) orelse return error.MalformedFixture, T);
+}
+
+fn hexIntArray(alloc: std.mem.Allocator, value: std.json.Value, comptime T: type) ParseError![]T {
+    const array = arrayOf(value) orelse return error.MalformedFixture;
+
+    const out = try alloc.alloc(T, array.items.len);
+    for (array.items, 0..) |item, i| out[i] = try hexInt(item, T);
+    return out;
+}
+
+fn hexBytesString(alloc: std.mem.Allocator, string: []const u8) ParseError![]u8 {
+    const digits = stripHexPrefix(string);
+    if (digits.len % 2 != 0) return error.MalformedHex;
+
+    const out = try alloc.alloc(u8, digits.len / 2);
+    _ = std.fmt.hexToBytes(out, digits) catch return error.MalformedHex;
+    return out;
+}
+
+fn hexBytesField(alloc: std.mem.Allocator, object: std.json.ObjectMap, field: []const u8) ParseError![]u8 {
+    const value = object.get(field) orelse return error.MalformedFixture;
+    return hexBytesString(alloc, stringOf(value) orelse return error.MalformedFixture);
+}
+
+fn hexBytesArray(alloc: std.mem.Allocator, value: std.json.Value) ParseError![]const []const u8 {
+    const array = arrayOf(value) orelse return error.MalformedFixture;
+
+    const out = try alloc.alloc([]const u8, array.items.len);
+    for (array.items, 0..) |item, i| {
+        out[i] = try hexBytesString(alloc, stringOf(item) orelse return error.MalformedFixture);
+    }
+    return out;
+}
+
+/// Hash fields are parsed as integers then re-serialised so that short or
+/// unpadded hex (e.g. "0x00") still lands in a [32]u8 correctly.
+fn hexHash(value: std.json.Value) ParseError![32]u8 {
+    const parsed = try hexInt(value, u256);
+    var out: [32]u8 = undefined;
+    std.mem.writeInt(u256, &out, parsed, .big);
+    return out;
+}
+
+fn indexField(object: std.json.ObjectMap, field: []const u8) ParseError!usize {
+    const value = object.get(field) orelse return error.MalformedFixture;
+    return switch (value) {
+        .integer => |integer| if (integer < 0) error.MalformedFixture else @intCast(integer),
+        else => error.MalformedFixture,
+    };
+}
+
+test "parse a minimal fixture" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const fixture =
+        \\{
+        \\ "tests/some_test.py::test_thing[fork_Cancun-state_test]": {
+        \\  "env": {
+        \\   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+        \\   "currentGasLimit": "0x07270e00",
+        \\   "currentNumber": "0x01",
+        \\   "currentTimestamp": "0x03e8",
+        \\   "currentRandom": "0x00",
+        \\   "currentBaseFee": "0x07"
+        \\  },
+        \\  "pre": {
+        \\   "0x0a16f360235334164b5f50ca2fa0d37e420cedb8": {
+        \\    "nonce": "0x00",
+        \\    "balance": "0x3635c9adc5dea00000",
+        \\    "code": "0x",
+        \\    "storage": { "0x01": "0x02" }
+        \\   }
+        \\  },
+        \\  "transaction": {
+        \\   "nonce": "0x00",
+        \\   "gasPrice": "0x0a",
+        \\   "gasLimit": ["0x0f4240"],
+        \\   "value": ["0x00"],
+        \\   "data": ["0x600100"],
+        \\   "sender": "0x0a16f360235334164b5f50ca2fa0d37e420cedb8",
+        \\   "to": ""
+        \\  },
+        \\  "post": {
+        \\   "Cancun": [
+        \\    {
+        \\     "hash": "0xdfe3e551e5a9ad38d8e078915698609e11a4fdd5fd4c0db4213a4532ab34ccee",
+        \\     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        \\     "txbytes": "0x00",
+        \\     "indexes": { "data": 0, "gas": 0, "value": 0 },
+        \\     "state": {}
+        \\    }
+        \\   ]
+        \\  },
+        \\  "config": { "chainid": "0x01" }
+        \\ }
+        \\}
+    ;
+
+    const cases = try parseSlice(arena.allocator(), fixture);
+    try std.testing.expectEqual(1, cases.len);
+
+    const case = cases[0];
+    try std.testing.expectEqual(0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba, case.env.coinbase);
+    try std.testing.expectEqual(7, case.env.base_fee);
+    try std.testing.expectEqual(1, case.pre.len);
+    try std.testing.expectEqual(1, case.pre[0].storage.len);
+    try std.testing.expectEqual(2, case.pre[0].storage[0].value);
+    try std.testing.expectEqual(null, case.transaction.to);
+    try std.testing.expectEqual(10, case.transaction.gas_price.?);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x60, 0x01, 0x00 }, case.transaction.datas[0]);
+    try std.testing.expectEqual(1, case.posts.len);
+    try std.testing.expectEqualStrings("Cancun", case.posts[0].fork);
+    try std.testing.expectEqual(null, case.posts[0].entries[0].expect_exception);
+    try std.testing.expectEqual(1, case.chain_id);
+}

--- a/spec/src/main.zig
+++ b/spec/src/main.zig
@@ -1,0 +1,270 @@
+//! Consume execution-spec-tests state test fixtures against zevem.
+//!
+//! Usage:
+//!   zevem-spec [--fork=Cancun] [--max=N] [--strict] [--verbose] [--evm-trace] PATH...
+//!
+//! PATH is a fixture JSON file or a directory which is walked recursively.
+//! See spec/README.org for the full story.
+
+const std = @import("std");
+
+const fixture = @import("fixture.zig");
+const runner = @import("runner.zig");
+
+const Options = struct {
+    fork: []const u8 = "Cancun",
+    max: ?usize = null,
+    strict: bool = false,
+    verbose: bool = false,
+    evm_trace: bool = false,
+    paths: []const []const u8 = &.{},
+};
+
+const Tally = struct {
+    pass: usize = 0,
+    pass_exception: usize = 0,
+    fail: usize = 0,
+    skip: std.EnumArray(runner.SkipReason, usize) = .initFill(0),
+    parse_failures: usize = 0,
+
+    fn executed(self: *const Tally) usize {
+        var skipped: usize = 0;
+        for (self.skip.values) |count| skipped += count;
+        return self.pass + self.pass_exception + self.fail + skipped;
+    }
+};
+
+const FailRecord = struct {
+    case_name: []const u8,
+    entry_index: usize,
+    message: []const u8,
+};
+
+const MAX_FAIL_RECORDS = 20;
+
+pub fn main() !void {
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
+
+    const options = parseArgs(args[1..]) catch {
+        try usage();
+        std.process.exit(2);
+    };
+
+    if (options.paths.len == 0) {
+        try usage();
+        std.process.exit(2);
+    }
+
+    // zevem's interpreter currently traces every executed opcode to stderr,
+    // which is noise at fixture volume. Silence it unless asked not to.
+    if (!options.evm_trace) try silenceStderr();
+
+    // Holds anything that must survive the whole run (fail records).
+    var run_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer run_arena.deinit();
+
+    const files = try collectFixtureFiles(run_arena.allocator(), options.paths);
+
+    var tally = Tally{};
+    var fails = std.ArrayListUnmanaged(FailRecord).empty;
+
+    // Per-file arena, reset between files to bound memory across thousands of
+    // fixtures.
+    var file_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer file_arena.deinit();
+
+    const stdout = std.io.getStdOut().writer();
+
+    files: for (files) |path| {
+        _ = file_arena.reset(.retain_capacity);
+        const file_alloc = file_arena.allocator();
+
+        const bytes = std.fs.cwd().readFileAlloc(file_alloc, path, 1 << 30) catch |err| {
+            try stdout.print("error: cannot read {s}: {s}\n", .{ path, @errorName(err) });
+            tally.parse_failures += 1;
+            continue;
+        };
+
+        const cases = fixture.parseSlice(file_alloc, bytes) catch |err| {
+            try stdout.print("error: cannot parse {s}: {s}\n", .{ path, @errorName(err) });
+            tally.parse_failures += 1;
+            continue;
+        };
+
+        for (cases) |case| {
+            var results = std.ArrayListUnmanaged(runner.EntryResult).empty;
+            try runner.runCase(file_alloc, case, options.fork, &results);
+
+            for (results.items) |result| {
+                switch (result.outcome) {
+                    .pass => tally.pass += 1,
+                    .pass_exception => tally.pass_exception += 1,
+                    .fail => |message| {
+                        tally.fail += 1;
+                        if (fails.items.len < MAX_FAIL_RECORDS) {
+                            // Copy out of the per-file arena.
+                            try fails.append(run_arena.allocator(), .{
+                                .case_name = try run_arena.allocator().dupe(u8, result.case_name),
+                                .entry_index = result.entry_index,
+                                .message = try run_arena.allocator().dupe(u8, message),
+                            });
+                        }
+                        if (options.verbose) {
+                            try stdout.print("FAIL {s} [{d}]\n  {s}\n", .{ result.case_name, result.entry_index, message });
+                        }
+                    },
+                    .skip => |reason| {
+                        tally.skip.getPtr(reason).* += 1;
+                        if (options.verbose and reason != .fork_filtered) {
+                            try stdout.print("SKIP {s} [{d}]: {s}\n", .{ result.case_name, result.entry_index, reason.describe() });
+                        }
+                    },
+                }
+
+                if (options.max) |max| {
+                    if (tally.executed() >= max) break :files;
+                }
+            }
+        }
+    }
+
+    try printSummary(stdout, &tally, fails.items, options);
+
+    if (options.strict and (tally.fail > 0 or tally.parse_failures > 0)) std.process.exit(1);
+}
+
+fn parseArgs(args: []const [:0]u8) !Options {
+    var options = Options{};
+
+    var paths = std.ArrayListUnmanaged([]const u8).empty;
+    // Lives as long as the process; freed by OS at exit.
+    const static_alloc = std.heap.page_allocator;
+
+    for (args) |arg| {
+        if (std.mem.startsWith(u8, arg, "--fork=")) {
+            options.fork = arg["--fork=".len..];
+        } else if (std.mem.startsWith(u8, arg, "--max=")) {
+            options.max = try std.fmt.parseInt(usize, arg["--max=".len..], 10);
+        } else if (std.mem.eql(u8, arg, "--strict")) {
+            options.strict = true;
+        } else if (std.mem.eql(u8, arg, "--verbose")) {
+            options.verbose = true;
+        } else if (std.mem.eql(u8, arg, "--evm-trace")) {
+            options.evm_trace = true;
+        } else if (std.mem.startsWith(u8, arg, "--")) {
+            return error.UnknownFlag;
+        } else {
+            try paths.append(static_alloc, arg);
+        }
+    }
+
+    options.paths = paths.items;
+    return options;
+}
+
+fn usage() !void {
+    try std.io.getStdOut().writer().writeAll(
+        \\usage: zevem-spec [--fork=Cancun] [--max=N] [--strict] [--verbose] [--evm-trace] PATH...
+        \\
+        \\Consumes execution-spec-tests state test fixtures (JSON files or
+        \\directories of them) and reports zevem's conformance.
+        \\
+        \\  --fork=NAME   Run post entries for this fork only (default Cancun).
+        \\  --max=N       Stop after N entries.
+        \\  --strict      Exit non-zero if any entry fails (for CI).
+        \\  --verbose     Print every failing and skipped entry as it happens.
+        \\  --evm-trace   Keep zevem's per-opcode stderr tracing.
+        \\
+    );
+}
+
+/// Redirect stderr to /dev/null. POSIX targets only; a no-op elsewhere.
+fn silenceStderr() !void {
+    if (@import("builtin").os.tag == .windows) return;
+
+    const null_fd = try std.posix.open("/dev/null", .{ .ACCMODE = .WRONLY }, 0);
+    defer std.posix.close(null_fd);
+    try std.posix.dup2(null_fd, std.posix.STDERR_FILENO);
+}
+
+/// Expand the given paths into a sorted list of fixture JSON files.
+fn collectFixtureFiles(alloc: std.mem.Allocator, paths: []const []const u8) ![]const []const u8 {
+    var files = std.ArrayListUnmanaged([]const u8).empty;
+
+    for (paths) |path| {
+        var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch |err| switch (err) {
+            error.NotDir => {
+                try files.append(alloc, try alloc.dupe(u8, path));
+                continue;
+            },
+            else => return err,
+        };
+        defer dir.close();
+
+        var walker = try dir.walk(alloc);
+        defer walker.deinit();
+
+        while (try walker.next()) |entry| {
+            if (entry.kind != .file) continue;
+            if (!std.mem.endsWith(u8, entry.basename, ".json")) continue;
+            try files.append(alloc, try std.fs.path.join(alloc, &.{ path, entry.path }));
+        }
+    }
+
+    std.mem.sort([]const u8, files.items, {}, pathLessThan);
+    return files.items;
+}
+
+fn pathLessThan(_: void, a: []const u8, b: []const u8) bool {
+    return std.mem.lessThan(u8, a, b);
+}
+
+fn printSummary(writer: anytype, tally: *const Tally, fails: []const FailRecord, options: Options) !void {
+    try writer.print("\nzevem-spec: fork {s}\n", .{options.fork});
+    try writer.print("{s}\n", .{"-" ** 72});
+
+    const executed = tally.executed();
+    try writer.print("entries:         {d}\n", .{executed});
+    try writer.print("pass:            {d}\n", .{tally.pass});
+    try writer.print("pass (rejected): {d}\n", .{tally.pass_exception});
+    try writer.print("fail:            {d}\n", .{tally.fail});
+
+    var skipped: usize = 0;
+    for (tally.skip.values) |count| skipped += count;
+    try writer.print("skip:            {d}\n", .{skipped});
+
+    inline for (std.meta.fields(runner.SkipReason)) |field| {
+        const reason: runner.SkipReason = @enumFromInt(field.value);
+        const count = tally.skip.get(reason);
+        if (count > 0) {
+            try writer.print("  {s}: {d} ({s})\n", .{ field.name, count, reason.describe() });
+        }
+    }
+
+    if (tally.parse_failures > 0) {
+        try writer.print("unparseable files: {d}\n", .{tally.parse_failures});
+    }
+
+    if (fails.len > 0) {
+        try writer.print("\nfirst {d} failures:\n", .{fails.len});
+        for (fails) |record| {
+            try writer.print("  {s} [{d}]\n", .{ record.case_name, record.entry_index });
+            var lines = std.mem.splitScalar(u8, std.mem.trimRight(u8, record.message, "\n"), '\n');
+            while (lines.next()) |line| try writer.print("    {s}\n", .{line});
+        }
+    }
+}
+
+test {
+    _ = @import("rlp.zig");
+    _ = @import("trie.zig");
+    _ = @import("state.zig");
+    _ = @import("fixture.zig");
+    _ = @import("runner.zig");
+    _ = @import("vendored_test.zig");
+}

--- a/spec/src/rlp.zig
+++ b/spec/src/rlp.zig
@@ -1,0 +1,130 @@
+//! Minimal RLP encoding, only what the spec harness needs (account bodies, trie
+//! nodes, storage values). Decoding is intentionally absent.
+//!
+//! Ref: YP Appendix B.
+
+const std = @import("std");
+
+const Bytes = std.ArrayListUnmanaged(u8);
+
+/// Encode a byte string per RLP rules, appending to `out`.
+pub fn encodeBytes(alloc: std.mem.Allocator, out: *Bytes, bytes: []const u8) !void {
+    if (bytes.len == 1 and bytes[0] < 0x80) {
+        try out.append(alloc, bytes[0]);
+        return;
+    }
+
+    try encodeLength(alloc, out, 0x80, bytes.len);
+    try out.appendSlice(alloc, bytes);
+}
+
+/// Encode an unsigned integer as its minimal big-endian byte string (no leading
+/// zeroes; zero is the empty string) per RLP rules, appending to `out`.
+pub fn encodeUint(alloc: std.mem.Allocator, out: *Bytes, value: u256) !void {
+    var buf: [32]u8 = undefined;
+    std.mem.writeInt(u256, &buf, value, .big);
+
+    const minimal = stripLeadingZeroes(&buf);
+    try encodeBytes(alloc, out, minimal);
+}
+
+/// Wrap an already RLP-encoded payload (a concatenation of encoded items) as a
+/// list, appending to `out`.
+pub fn encodeList(alloc: std.mem.Allocator, out: *Bytes, payload: []const u8) !void {
+    try encodeLength(alloc, out, 0xc0, payload.len);
+    try out.appendSlice(alloc, payload);
+}
+
+/// Strips leading zero bytes; the all-zero input collapses to the empty slice.
+pub fn stripLeadingZeroes(bytes: []const u8) []const u8 {
+    var start: usize = 0;
+    while (start < bytes.len and bytes[start] == 0) start += 1;
+    return bytes[start..];
+}
+
+fn encodeLength(alloc: std.mem.Allocator, out: *Bytes, base: u8, length: usize) !void {
+    if (length < 56) {
+        try out.append(alloc, base + @as(u8, @intCast(length)));
+        return;
+    }
+
+    var buf: [8]u8 = undefined;
+    std.mem.writeInt(u64, &buf, length, .big);
+    const minimal = stripLeadingZeroes(&buf);
+
+    try out.append(alloc, base + 55 + @as(u8, @intCast(minimal.len)));
+    try out.appendSlice(alloc, minimal);
+}
+
+test "rlp byte string forms" {
+    const alloc = std.testing.allocator;
+
+    // Single byte below 0x80 encodes as itself.
+    var a: Bytes = .empty;
+    defer a.deinit(alloc);
+    try encodeBytes(alloc, &a, &[_]u8{0x7f});
+    try std.testing.expectEqualSlices(u8, &[_]u8{0x7f}, a.items);
+
+    // Empty string is 0x80.
+    var b: Bytes = .empty;
+    defer b.deinit(alloc);
+    try encodeBytes(alloc, &b, &[_]u8{});
+    try std.testing.expectEqualSlices(u8, &[_]u8{0x80}, b.items);
+
+    // "dog" is 0x83 'd' 'o' 'g'.
+    var c: Bytes = .empty;
+    defer c.deinit(alloc);
+    try encodeBytes(alloc, &c, "dog");
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x83, 'd', 'o', 'g' }, c.items);
+
+    // 56-byte string takes the long form: 0xb8 0x38 ...
+    var d: Bytes = .empty;
+    defer d.deinit(alloc);
+    try encodeBytes(alloc, &d, "a" ** 56);
+    try std.testing.expectEqual(0xb8, d.items[0]);
+    try std.testing.expectEqual(0x38, d.items[1]);
+    try std.testing.expectEqual(58, d.items.len);
+}
+
+test "rlp integers" {
+    const alloc = std.testing.allocator;
+
+    // Zero is the empty string.
+    var a: Bytes = .empty;
+    defer a.deinit(alloc);
+    try encodeUint(alloc, &a, 0);
+    try std.testing.expectEqualSlices(u8, &[_]u8{0x80}, a.items);
+
+    // 15 is a single byte.
+    var b: Bytes = .empty;
+    defer b.deinit(alloc);
+    try encodeUint(alloc, &b, 15);
+    try std.testing.expectEqualSlices(u8, &[_]u8{0x0f}, b.items);
+
+    // 1024 is 0x82 0x04 0x00.
+    var c: Bytes = .empty;
+    defer c.deinit(alloc);
+    try encodeUint(alloc, &c, 1024);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x82, 0x04, 0x00 }, c.items);
+}
+
+test "rlp lists" {
+    const alloc = std.testing.allocator;
+
+    // Empty list is 0xc0.
+    var a: Bytes = .empty;
+    defer a.deinit(alloc);
+    try encodeList(alloc, &a, &[_]u8{});
+    try std.testing.expectEqualSlices(u8, &[_]u8{0xc0}, a.items);
+
+    // ["cat", "dog"] is 0xc8 0x83 'c' 'a' 't' 0x83 'd' 'o' 'g'.
+    var payload: Bytes = .empty;
+    defer payload.deinit(alloc);
+    try encodeBytes(alloc, &payload, "cat");
+    try encodeBytes(alloc, &payload, "dog");
+
+    var b: Bytes = .empty;
+    defer b.deinit(alloc);
+    try encodeList(alloc, &b, payload.items);
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0xc8, 0x83, 'c', 'a', 't', 0x83, 'd', 'o', 'g' }, b.items);
+}

--- a/spec/src/runner.zig
+++ b/spec/src/runner.zig
@@ -1,0 +1,626 @@
+//! Executes parsed state test fixtures against zevem and verifies the
+//! resulting world state.
+//!
+//! The harness acts as zevem's host: it owns the world state, applies the
+//! state transition surrounding EVM execution (YP section 6), invokes zevem
+//! for code execution, and verifies the post state both account-by-account
+//! and via the state root declared by the fixture.
+//!
+//! Cancun rules only. Anything the harness or zevem cannot faithfully execute
+//! is reported as a skip with a reason, never silently dropped.
+
+const std = @import("std");
+const Keccak256 = std.crypto.hash.sha3.Keccak256;
+
+const zevem = @import("zevem");
+
+const fixture = @import("fixture.zig");
+const rlp = @import("rlp.zig");
+const statefile = @import("state.zig");
+
+const StateDB = statefile.StateDB;
+const Address = statefile.Address;
+
+// NB: evm.New is generic over the environment but op.zig's dynamic gas
+// function pointers are typed against New(DummyEnv) specifically, so any
+// other environment type fails to instantiate; the harness therefore drives
+// DummyEnv directly. Its fields cover everything the EVM reads today except
+// per-address balances (DummyEnv.getBalance is hardcoded to zero), which only
+// the unfinished BALANCE opcode consumes.
+const EVM = zevem.EVM;
+const Exception = zevem.evm.Exception;
+
+/// Keccak-256 of RLP(()); the logs hash of an empty log series.
+const EMPTY_LOGS_HASH = [32]u8{
+    0x1d, 0xcc, 0x4d, 0xe8, 0xde, 0xc7, 0x5d, 0x7a, 0xab, 0x85, 0xb5, 0x67, 0xb6, 0xcc, 0xd4, 0x1a,
+    0xd3, 0x12, 0x45, 0x1b, 0x94, 0x8a, 0x74, 0x13, 0xf0, 0xa1, 0x42, 0xfd, 0x40, 0xd4, 0x93, 0x47,
+};
+
+// Cancun protocol parameters.
+const MAX_CODE_SIZE = 24_576; // EIP-170
+const MAX_INITCODE_SIZE = 2 * MAX_CODE_SIZE; // EIP-3860
+const G_TRANSACTION = 21_000;
+const G_TXDATA_ZERO = 4;
+const G_TXDATA_NONZERO = 16;
+const G_TXCREATE = 32_000;
+const G_INITCODE_WORD = 2;
+const G_ACCESS_LIST_ADDRESS = 2_400;
+const G_ACCESS_LIST_STORAGE_KEY = 1_900;
+const G_CODE_DEPOSIT = 200;
+
+pub const SkipReason = enum {
+    /// Post entries for forks other than the one requested.
+    fork_filtered,
+    /// Transaction type the harness does not execute (blob, set-code).
+    tx_type_unsupported,
+    /// zevem returned Exception.NotImplemented (opcode pending).
+    evm_unimplemented,
+    /// zevem requested host orchestration (CREATE/CALL family); resumable
+    /// execution is not finished on the zevem side yet.
+    evm_orchestrate,
+    /// The transaction targets a precompiled contract; precompiles are not
+    /// implemented (in zevem or the harness) yet.
+    precompile_unsupported,
+    /// The fixture expects log output; zevem does not collect logs yet so the
+    /// declared logs hash cannot be verified.
+    logs_uncollected,
+    /// A harness limitation (e.g. value does not fit the type zevem uses).
+    harness_limit,
+
+    pub fn describe(self: SkipReason) []const u8 {
+        return switch (self) {
+            .fork_filtered => "post entries for a non-selected fork",
+            .tx_type_unsupported => "unsupported transaction type (blob or set-code)",
+            .evm_unimplemented => "opcode not implemented by zevem yet",
+            .evm_orchestrate => "needs host orchestration (CREATE/CALL pending in zevem)",
+            .precompile_unsupported => "transaction targets a precompile; precompiles pending",
+            .logs_uncollected => "fixture expects logs; zevem does not collect logs yet",
+            .harness_limit => "harness limitation",
+        };
+    }
+};
+
+pub const Outcome = union(enum) {
+    /// Executed and the post state (accounts and root) matched.
+    pass,
+    /// Transaction was rejected and the fixture expected a rejection; the
+    /// (unchanged) post state matched.
+    pass_exception,
+    fail: []const u8,
+    skip: SkipReason,
+};
+
+pub const EntryResult = struct {
+    case_name: []const u8,
+    fork: []const u8,
+    entry_index: usize,
+    outcome: Outcome,
+};
+
+/// Run every post entry of `case` whose fork matches `fork_filter`, appending
+/// to `results`. `alloc` must be an arena; per-entry state is built fresh so
+/// entries are independent.
+pub fn runCase(
+    alloc: std.mem.Allocator,
+    case: fixture.TestCase,
+    fork_filter: []const u8,
+    results: *std.ArrayListUnmanaged(EntryResult),
+) !void {
+    for (case.posts) |post| {
+        const matches = std.mem.eql(u8, post.fork, fork_filter);
+
+        for (post.entries, 0..) |entry, i| {
+            const outcome = if (!matches)
+                Outcome{ .skip = .fork_filtered }
+            else
+                runEntry(alloc, case, entry) catch |err| switch (err) {
+                    error.OutOfMemory => return err,
+                };
+
+            try results.append(alloc, .{
+                .case_name = case.name,
+                .fork = post.fork,
+                .entry_index = i,
+                .outcome = outcome,
+            });
+        }
+    }
+}
+
+fn runEntry(
+    alloc: std.mem.Allocator,
+    case: fixture.TestCase,
+    entry: fixture.PostEntry,
+) error{OutOfMemory}!Outcome {
+    const tx = case.transaction;
+
+    if (tx.has_blobs or tx.has_authorizations) return .{ .skip = .tx_type_unsupported };
+
+    // Select the concrete transaction this post entry describes.
+    if (entry.gas_index >= tx.gas_limits.len or
+        entry.value_index >= tx.values.len or
+        entry.data_index >= tx.datas.len)
+    {
+        return .{ .fail = "post entry indexes out of range of transaction vectors" };
+    }
+
+    const gas_limit_wide = tx.gas_limits[entry.gas_index];
+    const value = tx.values[entry.value_index];
+    const data = tx.datas[entry.data_index];
+    const access_list: []const fixture.AccessListEntry = if (tx.access_lists) |lists| blk: {
+        if (entry.data_index >= lists.len) return .{ .fail = "access list vector shorter than data vector" };
+        break :blk lists[entry.data_index];
+    } else &.{};
+
+    // Build the pre state.
+    var state = StateDB.init(alloc);
+    for (case.pre) |account| try loadAccount(&state, account);
+
+    // Apply the state transition; on a validation failure the state is left
+    // untouched and the fixture is expected to declare an exception.
+    const rejection = try applyTransaction(alloc, &state, case, .{
+        .gas_limit_wide = gas_limit_wide,
+        .value = value,
+        .data = data,
+        .access_list = access_list,
+    });
+
+    switch (rejection) {
+        .executed => {
+            if (entry.expect_exception) |exception| {
+                return .{ .fail = try std.fmt.allocPrint(
+                    alloc,
+                    "fixture expects transaction exception ({s}) but the transaction was accepted",
+                    .{exception},
+                ) };
+            }
+        },
+        .invalid => |reason| {
+            if (entry.expect_exception == null) {
+                return .{ .fail = try std.fmt.allocPrint(
+                    alloc,
+                    "transaction rejected ({s}) but fixture expects acceptance",
+                    .{reason},
+                ) };
+            }
+            // Expected rejection; fall through to post-state verification of
+            // the untouched state.
+        },
+        .skipped => |reason| return .{ .skip = reason },
+    }
+
+    // The fixture's logs hash is unverifiable while zevem does not collect
+    // logs; only the empty hash can be confirmed.
+    if (!std.mem.eql(u8, &entry.logs_hash, &EMPTY_LOGS_HASH)) {
+        return .{ .skip = .logs_uncollected };
+    }
+
+    if (try diffState(alloc, &state, entry.state)) |diff| return .{ .fail = diff };
+
+    const root = try state.root();
+    if (!std.mem.eql(u8, &root, &entry.hash)) {
+        return .{ .fail = try std.fmt.allocPrint(
+            alloc,
+            "accounts match the fixture but the state root does not (got {x}, want {x}); harness trie bug",
+            .{ &root, &entry.hash },
+        ) };
+    }
+
+    return if (rejection == .invalid) .pass_exception else .pass;
+}
+
+fn loadAccount(state: *StateDB, account: fixture.Account) !void {
+    const loaded = try state.getOrCreate(account.address);
+    loaded.nonce = account.nonce;
+    loaded.balance = account.balance;
+    loaded.code = account.code;
+    for (account.storage) |slot| {
+        try state.setStorage(account.address, slot.key, slot.value);
+    }
+}
+
+const ConcreteTx = struct {
+    gas_limit_wide: u256,
+    value: u256,
+    data: []const u8,
+    access_list: []const fixture.AccessListEntry,
+};
+
+const TransitionResult = union(enum) {
+    executed,
+    /// Transaction validation failed; state unchanged.
+    invalid: []const u8,
+    skipped: SkipReason,
+};
+
+/// State transition for one transaction: YP section 6 (Cancun rules), with
+/// zevem providing code execution.
+fn applyTransaction(
+    alloc: std.mem.Allocator,
+    state: *StateDB,
+    case: fixture.TestCase,
+    tx: ConcreteTx,
+) error{OutOfMemory}!TransitionResult {
+    const env = case.env;
+    const declared = case.transaction;
+    const is_creation = declared.to == null;
+
+    // ////////////////////////////////////////////////////////////////////////
+    // //////////////// Validation. No state is modified before all checks pass.
+
+    if (tx.gas_limit_wide > env.gas_limit) return .{ .invalid = "gas limit exceeds block gas allowance" };
+    const gas_limit: u64 = std.math.cast(u64, tx.gas_limit_wide) orelse
+        return .{ .invalid = "gas limit exceeds block gas allowance" };
+
+    const intrinsic = intrinsicGas(tx.data, is_creation, tx.access_list);
+    if (gas_limit < intrinsic) return .{ .invalid = "intrinsic gas exceeds gas limit" };
+
+    if (is_creation and tx.data.len > MAX_INITCODE_SIZE) return .{ .invalid = "initcode size exceeded" };
+
+    const sender = try state.getOrCreate(declared.sender);
+    if (sender.code.len != 0) return .{ .invalid = "sender is not an EOA" };
+    if (sender.nonce != declared.nonce) return .{ .invalid = "nonce mismatch" };
+    if (declared.nonce == std.math.maxInt(u64)) return .{ .invalid = "nonce is at maximum" };
+
+    // Effective gas price: YP (66)-(68). Legacy transactions express their
+    // whole price in gasPrice; EIP-1559 ones bound base and priority fees.
+    var max_charged: u256 = undefined;
+    var effective_price: u256 = undefined;
+    if (declared.gas_price) |price| {
+        if (price < env.base_fee) return .{ .invalid = "gas price below base fee" };
+        max_charged = price;
+        effective_price = price;
+    } else if (declared.max_fee_per_gas) |max_fee| {
+        const max_priority = declared.max_priority_fee_per_gas orelse 0;
+        if (max_priority > max_fee) return .{ .invalid = "priority fee greater than max fee" };
+        if (max_fee < env.base_fee) return .{ .invalid = "max fee below base fee" };
+        max_charged = max_fee;
+        effective_price = @min(max_priority, max_fee - env.base_fee) + env.base_fee;
+    } else {
+        return .{ .invalid = "transaction declares no gas price" };
+    }
+
+    const max_gas_fee = std.math.mul(u256, max_charged, gas_limit) catch
+        return .{ .invalid = "gas limit and price product overflows" };
+    const required_balance = std.math.add(u256, max_gas_fee, tx.value) catch
+        return .{ .invalid = "required balance overflows" };
+    if (sender.balance < required_balance) return .{ .invalid = "insufficient account funds" };
+
+    // ////////////////////////////////////////////////////////////////////////
+    // //////////////// Irrevocable transaction cost: gas purchase and nonce.
+
+    sender.balance -= effective_price * gas_limit;
+    sender.nonce += 1;
+
+    // Changes from here on revert if execution fails.
+    const snapshot = try state.clone();
+
+    const target: Address = if (declared.to) |to|
+        to
+    else
+        createdAddress(alloc, declared.sender, declared.nonce) catch return error.OutOfMemory;
+
+    var gas_left: u64 = gas_limit - intrinsic;
+    var success = true;
+
+    const execution: ExecutionResult = blk: {
+        if (is_creation) {
+            // Creation collision (existing nonce or code): exceptional halt.
+            // Ref: YP (89).
+            if (state.get(target)) |existing| {
+                if (existing.nonce != 0 or existing.code.len != 0) {
+                    break :blk .{ .halt = {} };
+                }
+            }
+
+            // NB: deduct from the sender before taking the created-account
+            // pointer; getOrCreate may rehash and invalidate prior pointers.
+            (try state.getOrCreate(declared.sender)).balance -= tx.value;
+
+            const created = try state.getOrCreate(target);
+            created.nonce = 1; // EIP-161.
+            created.balance += tx.value;
+
+            break :blk runEvm(alloc, state, case, .{
+                .sender = declared.sender,
+                .target = target,
+                .value = tx.value,
+                .gas = gas_left,
+                .effective_price = effective_price,
+                .code = tx.data,
+                .data = &.{},
+            });
+        }
+
+        // Precompiled contracts have no code in the state; executing them
+        // requires the precompile implementations (Cancun: 0x01 to 0x0a).
+        if (target >= 0x01 and target <= 0x0a) {
+            return .{ .skipped = .precompile_unsupported };
+        }
+
+        (try state.getOrCreate(declared.sender)).balance -= tx.value;
+        try state.addBalance(target, tx.value);
+
+        const code = if (state.get(target)) |account| account.code else &[_]u8{};
+        if (code.len == 0) break :blk .{ .success = .{ .gas_left = gas_left, .output = &.{} } };
+
+        break :blk runEvm(alloc, state, case, .{
+            .sender = declared.sender,
+            .target = target,
+            .value = tx.value,
+            .gas = gas_left,
+            .effective_price = effective_price,
+            .code = code,
+            .data = tx.data,
+        });
+    };
+
+    switch (execution) {
+        .success => |result| {
+            gas_left = result.gas_left;
+
+            if (is_creation) {
+                // Code deposit: G_codedeposit per byte, EIP-3541 (no 0xEF
+                // prefix), EIP-170 (size cap). Failure is an exceptional halt.
+                const deposit_cost = G_CODE_DEPOSIT * result.output.len;
+                const deposit_ok = deposit_cost <= gas_left and
+                    result.output.len <= MAX_CODE_SIZE and
+                    (result.output.len == 0 or result.output[0] != 0xef);
+
+                if (deposit_ok) {
+                    gas_left -= @intCast(deposit_cost);
+                    (try state.getOrCreate(target)).code = result.output;
+                } else {
+                    success = false;
+                    gas_left = 0;
+                }
+            }
+        },
+        .revert => |result| {
+            success = false;
+            gas_left = result.gas_left;
+        },
+        .halt => {
+            success = false;
+            gas_left = 0;
+        },
+        .skip => |reason| return .{ .skipped = reason },
+    }
+
+    if (!success) {
+        // Restore every effect of execution; gas purchase and nonce increment
+        // were applied to the snapshot as well so they survive.
+        state.accounts = snapshot.accounts;
+    }
+
+    // ////////////////////////////////////////////////////////////////////////
+    // //////////////// Settlement: gas refund, priority fee, empties cleanup.
+
+    // No SSTORE/SELFDESTRUCT refund counter exists in zevem yet, so the
+    // EIP-3529 refund is always zero.
+    const gas_used = gas_limit - gas_left;
+
+    try state.addBalance(declared.sender, effective_price * gas_left);
+
+    const priority_fee = effective_price - env.base_fee;
+    const coinbase_reward = priority_fee * gas_used;
+    if (coinbase_reward != 0) {
+        try state.addBalance(env.coinbase, coinbase_reward);
+    } else if (state.get(env.coinbase)) |coinbase| {
+        // EIP-161: an already-empty coinbase receiving nothing is destroyed.
+        if (coinbase.isEmpty()) state.delete(env.coinbase);
+    }
+
+    // EIP-161 touched-account cleanup, limited to the accounts this harness
+    // can touch (no inner calls happen yet).
+    if (success) {
+        if (state.get(target)) |account| {
+            if (account.isEmpty()) state.delete(target);
+        }
+    }
+    if (state.get(declared.sender)) |account| {
+        if (account.isEmpty()) state.delete(declared.sender);
+    }
+
+    return .executed;
+}
+
+const EvmInvocation = struct {
+    sender: Address,
+    target: Address,
+    value: u256,
+    gas: u64,
+    effective_price: u256,
+    code: []const u8,
+    data: []const u8,
+};
+
+const ExecutionResult = union(enum) {
+    success: struct { gas_left: u64, output: []const u8 },
+    revert: struct { gas_left: u64 },
+    halt,
+    skip: SkipReason,
+};
+
+fn runEvm(
+    alloc: std.mem.Allocator,
+    state: *StateDB,
+    case: fixture.TestCase,
+    invocation: EvmInvocation,
+) ExecutionResult {
+    // zevem types gas_price as u64; fixture prices are word sized.
+    const gas_price: u64 = std.math.cast(u64, invocation.effective_price) orelse
+        return .{ .skip = .harness_limit };
+
+    var env = zevem.DummyEnv{
+        .block = .{
+            .parent_hash = [_]u8{0} ** 32,
+            .beneficiary = case.env.coinbase,
+            .number = case.env.number,
+            .gas_limit = case.env.gas_limit,
+            .timestamp = case.env.timestamp,
+            .randao = case.env.random,
+            .base_fee = case.env.base_fee,
+        },
+        .chain_id = case.chain_id,
+        .target_balance = state.balanceOf(invocation.target),
+    };
+
+    var evm = EVM.init(alloc, &env) catch return .{ .skip = .harness_limit };
+
+    // zevem charges G_transaction itself inside execute(); the full intrinsic
+    // cost was already deducted by the caller, so hand it the remaining gas
+    // plus the amount it is about to charge.
+    evm.execute(.{
+        .sender = invocation.sender,
+        .target = invocation.target,
+        .value = invocation.value,
+        .gas = invocation.gas + G_TRANSACTION,
+        .gas_price = gas_price,
+        .code = invocation.code,
+        .data = invocation.data,
+    }) catch |err| return switch (err) {
+        Exception.Revert => .{ .revert = .{ .gas_left = evm.gas } },
+        Exception.NotImplemented => .{ .skip = .evm_unimplemented },
+        Exception.Orchestrate => .{ .skip = .evm_orchestrate },
+        Exception.OutOfMemory => .{ .skip = .harness_limit },
+        // Exceptional halts consume all remaining gas.
+        Exception.OutOfGas,
+        Exception.InvalidOp,
+        Exception.InvalidJumpDestination,
+        Exception.StackUnderflow,
+        Exception.StackOverflow,
+        Exception.Overflow,
+        Exception.MemResizeUInt256Overflow,
+        => .halt,
+    };
+
+    return .{ .success = .{ .gas_left = evm.gas, .output = evm.return_data } };
+}
+
+/// Intrinsic gas g_0: YP (64)-(68), Cancun rules.
+fn intrinsicGas(data: []const u8, is_creation: bool, access_list: []const fixture.AccessListEntry) u64 {
+    var gas: u64 = G_TRANSACTION;
+
+    for (data) |byte| {
+        gas += if (byte == 0) G_TXDATA_ZERO else G_TXDATA_NONZERO;
+    }
+
+    if (is_creation) {
+        gas += G_TXCREATE;
+        // EIP-3860 initcode word cost.
+        gas += G_INITCODE_WORD * ((data.len + 31) / 32);
+    }
+
+    for (access_list) |entry| {
+        gas += G_ACCESS_LIST_ADDRESS;
+        gas += G_ACCESS_LIST_STORAGE_KEY * entry.storage_keys.len;
+    }
+
+    return gas;
+}
+
+/// Contract address for a creation transaction: KEC(RLP([sender, nonce]))[12..].
+/// Ref: YP (85).
+fn createdAddress(alloc: std.mem.Allocator, sender: Address, nonce: u64) !Address {
+    var sender_bytes: [20]u8 = undefined;
+    std.mem.writeInt(u160, &sender_bytes, sender, .big);
+
+    var payload: std.ArrayListUnmanaged(u8) = .empty;
+    try rlp.encodeBytes(alloc, &payload, &sender_bytes);
+    try rlp.encodeUint(alloc, &payload, nonce);
+
+    var encoded: std.ArrayListUnmanaged(u8) = .empty;
+    try rlp.encodeList(alloc, &encoded, payload.items);
+
+    var hash: [32]u8 = undefined;
+    Keccak256.hash(encoded.items, &hash, .{});
+
+    return std.mem.readInt(u160, hash[12..32], .big);
+}
+
+/// Compare the harness state against the fixture's expected post state.
+/// Returns a human-readable diff on mismatch, null when they agree.
+fn diffState(
+    alloc: std.mem.Allocator,
+    state: *StateDB,
+    expected: []const fixture.Account,
+) error{OutOfMemory}!?[]const u8 {
+    var diff: std.ArrayListUnmanaged(u8) = .empty;
+    const writer = diff.writer(alloc);
+
+    var mismatches: usize = 0;
+    const mismatch_cap = 8;
+
+    for (expected) |want| {
+        if (mismatches >= mismatch_cap) break;
+
+        const got = state.get(want.address) orelse {
+            // The fixture sometimes spells out explicitly-empty accounts.
+            if (want.nonce == 0 and want.balance == 0 and want.code.len == 0 and want.storage.len == 0) continue;
+
+            try writer.print("account 0x{x:0>40} missing\n", .{want.address});
+            mismatches += 1;
+            continue;
+        };
+
+        if (got.nonce != want.nonce) {
+            try writer.print("account 0x{x:0>40}: nonce {d}, want {d}\n", .{ want.address, got.nonce, want.nonce });
+            mismatches += 1;
+        }
+        if (got.balance != want.balance) {
+            try writer.print("account 0x{x:0>40}: balance {d}, want {d}\n", .{ want.address, got.balance, want.balance });
+            mismatches += 1;
+        }
+        if (!std.mem.eql(u8, got.code, want.code)) {
+            try writer.print("account 0x{x:0>40}: code mismatch ({d} bytes, want {d})\n", .{ want.address, got.code.len, want.code.len });
+            mismatches += 1;
+        }
+
+        for (want.storage) |slot| {
+            const got_value = got.storage.get(slot.key) orelse 0;
+            if (got_value != slot.value) {
+                try writer.print("account 0x{x:0>40}: storage[0x{x}] = 0x{x}, want 0x{x}\n", .{ want.address, slot.key, got_value, slot.value });
+                mismatches += 1;
+            }
+        }
+
+        // Storage slots we hold that the fixture does not expect.
+        var it = got.storage.iterator();
+        slots: while (it.next()) |kv| {
+            for (want.storage) |slot| {
+                if (slot.key == kv.key_ptr.*) continue :slots;
+            }
+            try writer.print("account 0x{x:0>40}: unexpected storage[0x{x}] = 0x{x}\n", .{ want.address, kv.key_ptr.*, kv.value_ptr.* });
+            mismatches += 1;
+        }
+    }
+
+    // Accounts we hold that the fixture post state does not mention at all.
+    var it = state.accounts.iterator();
+    accounts: while (it.next()) |kv| {
+        if (mismatches >= mismatch_cap) break;
+        for (expected) |want| {
+            if (want.address == kv.key_ptr.*) continue :accounts;
+        }
+        try writer.print("unexpected account 0x{x:0>40}\n", .{kv.key_ptr.*});
+        mismatches += 1;
+    }
+
+    if (mismatches == 0) return null;
+    return diff.items;
+}
+
+test "created contract address derivation" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    // Well-known vector: sender 0x6ac7ea33f8831ea9dcc53393aaa88b25a785dbf0
+    // with nonce 0 creates 0xcd234a471b72ba2f1ccf0a70fcaba648a5eecd8d.
+    const created = try createdAddress(
+        arena.allocator(),
+        0x6ac7ea33f8831ea9dcc53393aaa88b25a785dbf0,
+        0,
+    );
+    try std.testing.expectEqual(0xcd234a471b72ba2f1ccf0a70fcaba648a5eecd8d, created);
+}

--- a/spec/src/state.zig
+++ b/spec/src/state.zig
@@ -1,0 +1,196 @@
+//! In-memory world state (σ) for the spec harness: a flat map of accounts with
+//! storage, plus state root computation over it.
+//!
+//! All allocation is assumed arena-backed (one arena per executed test case),
+//! so nothing is individually freed and clones are cheap to reason about.
+
+const std = @import("std");
+const Keccak256 = std.crypto.hash.sha3.Keccak256;
+
+const rlp = @import("rlp.zig");
+const trie = @import("trie.zig");
+
+const Bytes = std.ArrayListUnmanaged(u8);
+
+pub const Address = u160;
+
+pub const Account = struct {
+    nonce: u64 = 0,
+    balance: u256 = 0,
+    code: []const u8 = &.{},
+    storage: std.AutoHashMapUnmanaged(u256, u256) = .empty,
+
+    /// Empty per EIP-161: no code, zero nonce, zero balance.
+    pub fn isEmpty(self: *const Account) bool {
+        return self.nonce == 0 and self.balance == 0 and self.code.len == 0;
+    }
+};
+
+pub const StateDB = struct {
+    const Self = @This();
+
+    alloc: std.mem.Allocator,
+    accounts: std.AutoHashMapUnmanaged(Address, Account),
+
+    pub fn init(alloc: std.mem.Allocator) Self {
+        return .{ .alloc = alloc, .accounts = .empty };
+    }
+
+    pub fn get(self: *Self, addr: Address) ?*Account {
+        return self.accounts.getPtr(addr);
+    }
+
+    pub fn getOrCreate(self: *Self, addr: Address) !*Account {
+        const gop = try self.accounts.getOrPut(self.alloc, addr);
+        if (!gop.found_existing) gop.value_ptr.* = .{};
+        return gop.value_ptr;
+    }
+
+    pub fn balanceOf(self: *Self, addr: Address) u256 {
+        return if (self.get(addr)) |account| account.balance else 0;
+    }
+
+    pub fn addBalance(self: *Self, addr: Address, amount: u256) !void {
+        const account = try self.getOrCreate(addr);
+        account.balance += amount;
+    }
+
+    pub fn setStorage(self: *Self, addr: Address, key: u256, value: u256) !void {
+        const account = try self.getOrCreate(addr);
+        if (value == 0) {
+            _ = account.storage.remove(key);
+        } else {
+            try account.storage.put(self.alloc, key, value);
+        }
+    }
+
+    pub fn delete(self: *Self, addr: Address) void {
+        _ = self.accounts.remove(addr);
+    }
+
+    /// Deep copy, for snapshot/revert semantics around transaction execution.
+    pub fn clone(self: *Self) !Self {
+        var copy = Self.init(self.alloc);
+        var it = self.accounts.iterator();
+        while (it.next()) |kv| {
+            const account = kv.value_ptr;
+            try copy.accounts.put(self.alloc, kv.key_ptr.*, .{
+                .nonce = account.nonce,
+                .balance = account.balance,
+                // Code is never mutated in place, share the slice.
+                .code = account.code,
+                .storage = try account.storage.clone(self.alloc),
+            });
+        }
+        return copy;
+    }
+
+    /// World state root: secure trie over RLP-encoded account bodies.
+    /// Ref: YP 4.1.
+    pub fn root(self: *Self) ![32]u8 {
+        const pairs = try self.alloc.alloc(trie.Pair, self.accounts.count());
+
+        var it = self.accounts.iterator();
+        var i: usize = 0;
+        while (it.next()) |kv| : (i += 1) {
+            const key = try self.alloc.alloc(u8, 20);
+            std.mem.writeInt(u160, key[0..20], kv.key_ptr.*, .big);
+
+            pairs[i] = .{ .key = key, .value = try encodeAccount(self.alloc, kv.value_ptr) };
+        }
+
+        return trie.secureRoot(self.alloc, pairs);
+    }
+
+    /// Account body: RLP([nonce, balance, storage root, code hash]).
+    fn encodeAccount(alloc: std.mem.Allocator, account: *const Account) ![]const u8 {
+        var payload: Bytes = .empty;
+        try rlp.encodeUint(alloc, &payload, account.nonce);
+        try rlp.encodeUint(alloc, &payload, account.balance);
+
+        const storage_root = try storageRoot(alloc, account);
+        try rlp.encodeBytes(alloc, &payload, &storage_root);
+
+        var code_hash: [32]u8 = undefined;
+        Keccak256.hash(account.code, &code_hash, .{});
+        try rlp.encodeBytes(alloc, &payload, &code_hash);
+
+        var body: Bytes = .empty;
+        try rlp.encodeList(alloc, &body, payload.items);
+        return body.items;
+    }
+
+    /// Storage root: secure trie keyed by the 32-byte slot, holding the
+    /// RLP-encoded (minimal big-endian) value. Zero values are absent.
+    fn storageRoot(alloc: std.mem.Allocator, account: *const Account) ![32]u8 {
+        if (account.storage.count() == 0) return trie.EMPTY_ROOT;
+
+        const pairs = try alloc.alloc(trie.Pair, account.storage.count());
+
+        var it = account.storage.iterator();
+        var i: usize = 0;
+        while (it.next()) |kv| : (i += 1) {
+            std.debug.assert(kv.value_ptr.* != 0);
+
+            const key = try alloc.alloc(u8, 32);
+            std.mem.writeInt(u256, key[0..32], kv.key_ptr.*, .big);
+
+            var value: Bytes = .empty;
+            try rlp.encodeUint(alloc, &value, kv.value_ptr.*);
+
+            pairs[i] = .{ .key = key, .value = value.items };
+        }
+
+        return trie.secureRoot(alloc, pairs);
+    }
+};
+
+test "state root of empty state is the empty trie root" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var state = StateDB.init(arena.allocator());
+    try std.testing.expectEqual(trie.EMPTY_ROOT, try state.root());
+}
+
+test "state root matches execution-spec-tests fixture" {
+    // Post state of test_cover_revert[fork_Cancun-state_test] from EEST v5.4.0
+    // (fixtures/state_tests/frontier/opcodes/test_cover_revert.json), whose
+    // fixture-declared post hash is below. Exercises account encoding and a
+    // two-leaf trie against externally produced ground truth.
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var state = StateDB.init(arena.allocator());
+
+    const sender = try state.getOrCreate(0x0a16f360235334164b5f50ca2fa0d37e420cedb8);
+    sender.nonce = 0x01;
+    sender.balance = 0x3635c9adc5de94848c;
+
+    const coinbase = try state.getOrCreate(0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba);
+    coinbase.balance = 0x0371d6;
+
+    var expected: [32]u8 = undefined;
+    _ = try std.fmt.hexToBytes(&expected, "dfe3e551e5a9ad38d8e078915698609e11a4fdd5fd4c0db4213a4532ab34ccee");
+
+    try std.testing.expectEqual(expected, try state.root());
+}
+
+test "storage values participate in the state root" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var state = StateDB.init(arena.allocator());
+    _ = try state.getOrCreate(0x0a16f360235334164b5f50ca2fa0d37e420cedb8);
+
+    const without_storage = try state.root();
+
+    try state.setStorage(0x0a16f360235334164b5f50ca2fa0d37e420cedb8, 1, 2);
+    const with_storage = try state.root();
+
+    try std.testing.expect(!std.mem.eql(u8, &without_storage, &with_storage));
+
+    // Writing zero clears the slot and restores the prior root.
+    try state.setStorage(0x0a16f360235334164b5f50ca2fa0d37e420cedb8, 1, 0);
+    try std.testing.expectEqual(without_storage, try state.root());
+}

--- a/spec/src/testdata/stack_underflow.json
+++ b/spec/src/testdata/stack_underflow.json
@@ -1,0 +1,190 @@
+{
+ "tests/frontier/opcodes/test_swap.py::test_stack_underflow[fork_Cancun-state_test-SWAP10]": {
+  "env": {
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentGasLimit": "0x07270e00",
+   "currentNumber": "0x01",
+   "currentTimestamp": "0x03e8",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "currentDifficulty": "0x00",
+   "currentBaseFee": "0x07",
+   "currentExcessBlobGas": "0x00"
+  },
+  "pre": {
+   "0x295717b88c56a5ecfc11ebc6d562efd892c39ce9": {
+    "nonce": "0x01",
+    "balance": "0x00",
+    "code": "0x60006001600260036004600560066007600899600055",
+    "storage": {}
+   },
+   "0x825583747abbdda27a3d9e6155907bca4e581f31": {
+    "nonce": "0x00",
+    "balance": "0x3635c9adc5dea00000",
+    "code": "0x",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "nonce": "0x00",
+   "gasPrice": "0x0a",
+   "gasLimit": [
+    "0x07a120"
+   ],
+   "to": "0x295717b88c56a5ecfc11ebc6d562efd892c39ce9",
+   "value": [
+    "0x00"
+   ],
+   "data": [
+    "0x"
+   ],
+   "sender": "0x825583747abbdda27a3d9e6155907bca4e581f31",
+   "secretKey": "0x74a36dd06d7eb60582720445295717b88c56a5ecfc11ebc6d562efd892c39ce9"
+  },
+  "post": {
+   "Cancun": [
+    {
+     "hash": "0x6bd100f03e2c1d2c500b73f695faca3a69e85404acf81afc43b3f93117099efe",
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+     "txbytes": "0xf860800a8307a12094295717b88c56a5ecfc11ebc6d562efd892c39ce9808026a0dde59fe42d3e74f150f6332240af52bdc9e9043513217bf71ade1540ffdacd89a04c1886b7261e583091b8581ca9ba6b5d115b3a06d1d5313817a9950e845ade9b",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "state": {
+      "0x295717b88c56a5ecfc11ebc6d562efd892c39ce9": {
+       "nonce": "0x01",
+       "balance": "0x00",
+       "code": "0x60006001600260036004600560066007600899600055",
+       "storage": {}
+      },
+      "0x825583747abbdda27a3d9e6155907bca4e581f31": {
+       "nonce": "0x01",
+       "balance": "0x3635c9adc5de53b4c0",
+       "code": "0x",
+       "storage": {}
+      },
+      "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+       "nonce": "0x00",
+       "balance": "0x16e360",
+       "code": "0x",
+       "storage": {}
+      }
+     }
+    }
+   ]
+  },
+  "config": {
+   "blobSchedule": {
+    "Cancun": {
+     "target": "0x03",
+     "max": "0x06",
+     "baseFeeUpdateFraction": "0x32f0ed"
+    }
+   },
+   "chainid": "0x01"
+  },
+  "_info": {
+   "hash": "0xc2465f14cc18bb7d8041cfaa3f30dabea9286e74eee96db2a1ddbbb1c52ef53c",
+   "comment": "`execution-specs` generated test",
+   "filling-transition-tool": "2.18.0rc6",
+   "description": "A test to ensure that the stack underflow when there are not enough\n    elements for the `SWAP*` opcode to operate.\n\n    For each SWAPn operation, we push exactly (n-1) elements to cause an\n    underflow when trying to swap with the nth element.",
+   "url": "https://github.com/ethereum/execution-specs/blob/tests-v5.4.0/tests/frontier/opcodes/test_swap.py#L106",
+   "fixture-format": "state_test"
+  }
+ },
+ "tests/frontier/opcodes/test_swap.py::test_stack_underflow[fork_Cancun-state_test-SWAP11]": {
+  "env": {
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentGasLimit": "0x07270e00",
+   "currentNumber": "0x01",
+   "currentTimestamp": "0x03e8",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "currentDifficulty": "0x00",
+   "currentBaseFee": "0x07",
+   "currentExcessBlobGas": "0x00"
+  },
+  "pre": {
+   "0x75f6bdb5fb19674d7c65e882431dd64f8eab5982": {
+    "nonce": "0x01",
+    "balance": "0x00",
+    "code": "0x60006001600260036004600560066007600860099a600055",
+    "storage": {}
+   },
+   "0x993c4a4fd6611decefdabdff023458d734707700": {
+    "nonce": "0x00",
+    "balance": "0x3635c9adc5dea00000",
+    "code": "0x",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "nonce": "0x00",
+   "gasPrice": "0x0a",
+   "gasLimit": [
+    "0x07a120"
+   ],
+   "to": "0x75f6bdb5fb19674d7c65e882431dd64f8eab5982",
+   "value": [
+    "0x00"
+   ],
+   "data": [
+    "0x"
+   ],
+   "sender": "0x993c4a4fd6611decefdabdff023458d734707700",
+   "secretKey": "0x65d86eb833886910d6f48d4175f6bdb5fb19674d7c65e882431dd64f8eab5982"
+  },
+  "post": {
+   "Cancun": [
+    {
+     "hash": "0x35f6b9b1e63e658268ba5017fff399b58f968063999f6a9698ef1678b1294d97",
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+     "txbytes": "0xf860800a8307a1209475f6bdb5fb19674d7c65e882431dd64f8eab5982808026a075787895d1ea9e97643bb48784bdf5eb9b8fe79286e0e317de744a294c3785cea030b3a198f165eca6256df670c5d20f560b852fa08bf05bfa91bbbabb91ed6551",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "state": {
+      "0x75f6bdb5fb19674d7c65e882431dd64f8eab5982": {
+       "nonce": "0x01",
+       "balance": "0x00",
+       "code": "0x60006001600260036004600560066007600860099a600055",
+       "storage": {}
+      },
+      "0x993c4a4fd6611decefdabdff023458d734707700": {
+       "nonce": "0x01",
+       "balance": "0x3635c9adc5de53b4c0",
+       "code": "0x",
+       "storage": {}
+      },
+      "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+       "nonce": "0x00",
+       "balance": "0x16e360",
+       "code": "0x",
+       "storage": {}
+      }
+     }
+    }
+   ]
+  },
+  "config": {
+   "blobSchedule": {
+    "Cancun": {
+     "target": "0x03",
+     "max": "0x06",
+     "baseFeeUpdateFraction": "0x32f0ed"
+    }
+   },
+   "chainid": "0x01"
+  },
+  "_info": {
+   "hash": "0xfceaa6a0bd86e1e1ad955177f266af4bc20b82d2845d03d0afb14ea71a8d3a61",
+   "comment": "`execution-specs` generated test",
+   "filling-transition-tool": "2.18.0rc6",
+   "description": "A test to ensure that the stack underflow when there are not enough\n    elements for the `SWAP*` opcode to operate.\n\n    For each SWAPn operation, we push exactly (n-1) elements to cause an\n    underflow when trying to swap with the nth element.",
+   "url": "https://github.com/ethereum/execution-specs/blob/tests-v5.4.0/tests/frontier/opcodes/test_swap.py#L106",
+   "fixture-format": "state_test"
+  }
+ }
+}

--- a/spec/src/testdata/transaction_intrinsic_gas_cost.json
+++ b/spec/src/testdata/transaction_intrinsic_gas_cost.json
@@ -1,0 +1,418 @@
+{
+ "tests/berlin/eip2930_access_list/test_acl.py::test_transaction_intrinsic_gas_cost[fork_Cancun-state_test-enough_gas-empty_access_list]": {
+  "env": {
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentGasLimit": "0x07270e00",
+   "currentNumber": "0x01",
+   "currentTimestamp": "0x03e8",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "currentDifficulty": "0x00",
+   "currentBaseFee": "0x07",
+   "currentExcessBlobGas": "0x00"
+  },
+  "pre": {
+   "0xc3ea744aa6b9f501386aa167ad42f49e3787066f": {
+    "nonce": "0x01",
+    "balance": "0x03",
+    "code": "0x00",
+    "storage": {}
+   },
+   "0x9015bca99e8d49107c33b2cac14013a8dfd2c1b0": {
+    "nonce": "0x00",
+    "balance": "0x3635c9adc5dea00001",
+    "code": "0x",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "nonce": "0x00",
+   "gasPrice": "0x0a",
+   "gasLimit": [
+    "0x5208"
+   ],
+   "to": "0xc3ea744aa6b9f501386aa167ad42f49e3787066f",
+   "value": [
+    "0x01"
+   ],
+   "data": [
+    "0x"
+   ],
+   "accessLists": [
+    []
+   ],
+   "sender": "0x9015bca99e8d49107c33b2cac14013a8dfd2c1b0",
+   "secretKey": "0xa4e7ea6dc542e6de38bf1229c3ea744aa6b9f501386aa167ad42f49e3787066f"
+  },
+  "post": {
+   "Cancun": [
+    {
+     "hash": "0xf3167c98fea9b308233f046a2b4a22f090126b3133f1f890979cf9f397ecf067",
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+     "txbytes": "0x01f86101800a82520894c3ea744aa6b9f501386aa167ad42f49e3787066f0180c080a04c019ca87cdd7c7837f8d8b52a19ae28a40ba67bb9be0f527c136d03b7dea76fa03d3b393f4404074dead10838228d53cf10f8c075e734289962a40401b0a3c0c2",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "state": {
+      "0xc3ea744aa6b9f501386aa167ad42f49e3787066f": {
+       "nonce": "0x01",
+       "balance": "0x04",
+       "code": "0x00",
+       "storage": {}
+      },
+      "0x9015bca99e8d49107c33b2cac14013a8dfd2c1b0": {
+       "nonce": "0x01",
+       "balance": "0x3635c9adc5de9ccbb0",
+       "code": "0x",
+       "storage": {}
+      },
+      "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+       "nonce": "0x00",
+       "balance": "0xf618",
+       "code": "0x",
+       "storage": {}
+      }
+     }
+    }
+   ]
+  },
+  "config": {
+   "blobSchedule": {
+    "Cancun": {
+     "target": "0x03",
+     "max": "0x06",
+     "baseFeeUpdateFraction": "0x32f0ed"
+    }
+   },
+   "chainid": "0x01"
+  },
+  "_info": {
+   "hash": "0xf2a49bcfc0fd245f36a7e848eee79ec6969e63bfbf2a295ec92315a6ebaf69ef",
+   "comment": "`execution-specs` generated test",
+   "filling-transition-tool": "2.18.0rc6",
+   "description": "Test type 1 transaction.",
+   "url": "https://github.com/ethereum/execution-specs/blob/tests-v5.4.0/tests/berlin/eip2930_access_list/test_acl.py#L117",
+   "fixture-format": "state_test",
+   "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2930.md",
+   "reference-spec-version": "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
+  }
+ },
+ "tests/berlin/eip2930_access_list/test_acl.py::test_transaction_intrinsic_gas_cost[fork_Cancun-state_test-enough_gas-multiple_addresses_second_address_multiple_storage_keys]": {
+  "env": {
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentGasLimit": "0x07270e00",
+   "currentNumber": "0x01",
+   "currentTimestamp": "0x03e8",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "currentDifficulty": "0x00",
+   "currentBaseFee": "0x07",
+   "currentExcessBlobGas": "0x00"
+  },
+  "pre": {
+   "0x3e4bb016d28bc02bb9acb2c871d7a628e6181742": {
+    "nonce": "0x01",
+    "balance": "0x03",
+    "code": "0x00",
+    "storage": {}
+   },
+   "0xba26fdb6af4e29efac32606a159968eb715b21dd": {
+    "nonce": "0x00",
+    "balance": "0x3635c9adc5dea00001",
+    "code": "0x",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "nonce": "0x00",
+   "gasPrice": "0x0a",
+   "gasLimit": [
+    "0x8278"
+   ],
+   "to": "0x3e4bb016d28bc02bb9acb2c871d7a628e6181742",
+   "value": [
+    "0x01"
+   ],
+   "data": [
+    "0x"
+   ],
+   "accessLists": [
+    [
+     {
+      "address": "0x0000000000000000000000000000000000000000",
+      "storageKeys": [
+       "0x0000000000000000000000000000000000000000000000000000000000000000",
+       "0x0000000000000000000000000000000000000000000000000000000000000001"
+      ]
+     },
+     {
+      "address": "0x0000000000000000000000000000000000000001",
+      "storageKeys": [
+       "0x0000000000000000000000000000000000000000000000000000000000000000",
+       "0x0000000000000000000000000000000000000000000000000000000000000001"
+      ]
+     }
+    ]
+   ],
+   "sender": "0xba26fdb6af4e29efac32606a159968eb715b21dd",
+   "secretKey": "0xc10945025443cc330ec556743e4bb016d28bc02bb9acb2c871d7a628e6181742"
+  },
+  "post": {
+   "Cancun": [
+    {
+     "hash": "0xd0b39f9583723958b6efeadfd8a5a4918d743aab06c185b389b194ce1e5b2223",
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+     "txbytes": "0x01f9011801800a828278943e4bb016d28bc02bb9acb2c871d7a628e61817420180f8b6f859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001f859940000000000000000000000000000000000000001f842a00000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000101a07360aed1d141dbe5715a3033081fe3d300538e2b1f3c3c04829d4b403875b6b1a0440a6bd51f093a5b8e09e0363951beb72a6eaa724aca335a7a7ac9b6c6a77ff6",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "state": {
+      "0x3e4bb016d28bc02bb9acb2c871d7a628e6181742": {
+       "nonce": "0x01",
+       "balance": "0x04",
+       "code": "0x00",
+       "storage": {}
+      },
+      "0xba26fdb6af4e29efac32606a159968eb715b21dd": {
+       "nonce": "0x01",
+       "balance": "0x3635c9adc5de9ae750",
+       "code": "0x",
+       "storage": {}
+      },
+      "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba": {
+       "nonce": "0x00",
+       "balance": "0x018768",
+       "code": "0x",
+       "storage": {}
+      }
+     }
+    }
+   ]
+  },
+  "config": {
+   "blobSchedule": {
+    "Cancun": {
+     "target": "0x03",
+     "max": "0x06",
+     "baseFeeUpdateFraction": "0x32f0ed"
+    }
+   },
+   "chainid": "0x01"
+  },
+  "_info": {
+   "hash": "0x5e351eb3c0cfce301b402764f0a2449f1dfcdff3183f1a0af16c4d6a157c4a95",
+   "comment": "`execution-specs` generated test",
+   "filling-transition-tool": "2.18.0rc6",
+   "description": "Test type 1 transaction.",
+   "url": "https://github.com/ethereum/execution-specs/blob/tests-v5.4.0/tests/berlin/eip2930_access_list/test_acl.py#L117",
+   "fixture-format": "state_test",
+   "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2930.md",
+   "reference-spec-version": "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
+  }
+ },
+ "tests/berlin/eip2930_access_list/test_acl.py::test_transaction_intrinsic_gas_cost[fork_Cancun-state_test-not_enough_gas-empty_access_list]": {
+  "env": {
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentGasLimit": "0x07270e00",
+   "currentNumber": "0x01",
+   "currentTimestamp": "0x03e8",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "currentDifficulty": "0x00",
+   "currentBaseFee": "0x07",
+   "currentExcessBlobGas": "0x00"
+  },
+  "pre": {
+   "0x63716d51df8e0663571f03827f5eecf151623430": {
+    "nonce": "0x01",
+    "balance": "0x03",
+    "code": "0x00",
+    "storage": {}
+   },
+   "0xa56cbf7ad3a31bb67b6e182c13ee4b52a333f49c": {
+    "nonce": "0x00",
+    "balance": "0x3635c9adc5dea00001",
+    "code": "0x",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "nonce": "0x00",
+   "gasPrice": "0x0a",
+   "gasLimit": [
+    "0x5207"
+   ],
+   "to": "0x63716d51df8e0663571f03827f5eecf151623430",
+   "value": [
+    "0x01"
+   ],
+   "data": [
+    "0x"
+   ],
+   "accessLists": [
+    []
+   ],
+   "sender": "0xa56cbf7ad3a31bb67b6e182c13ee4b52a333f49c",
+   "secretKey": "0x865cf2659843b833ac0d880163716d51df8e0663571f03827f5eecf151623430"
+  },
+  "post": {
+   "Cancun": [
+    {
+     "hash": "0xfd8e78af6840c6c57572624e6737c0b9b2e83a9c30bcacc4d5cc22c07d6ef198",
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+     "txbytes": "0x01f86101800a8252079463716d51df8e0663571f03827f5eecf1516234300180c001a0f4dbe2d9e50adf8264a4fc5d2f51f4063b548c16aff75d538c76f52776331d9fa048b75b0b6535f4a10f572aef4a89bedbeaf2a95eeeac31f4031895cbb4e30e0b",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "state": {
+      "0x63716d51df8e0663571f03827f5eecf151623430": {
+       "nonce": "0x01",
+       "balance": "0x03",
+       "code": "0x00",
+       "storage": {}
+      },
+      "0xa56cbf7ad3a31bb67b6e182c13ee4b52a333f49c": {
+       "nonce": "0x00",
+       "balance": "0x3635c9adc5dea00001",
+       "code": "0x",
+       "storage": {}
+      }
+     },
+     "expectException": "TransactionException.INTRINSIC_GAS_TOO_LOW"
+    }
+   ]
+  },
+  "config": {
+   "blobSchedule": {
+    "Cancun": {
+     "target": "0x03",
+     "max": "0x06",
+     "baseFeeUpdateFraction": "0x32f0ed"
+    }
+   },
+   "chainid": "0x01"
+  },
+  "_info": {
+   "hash": "0x559cd6fe9b55e79c799e551eebad67beb49f3373e3c7034d7ffa6c81b297540e",
+   "comment": "`execution-specs` generated test",
+   "filling-transition-tool": "2.18.0rc6",
+   "description": "Test type 1 transaction.",
+   "url": "https://github.com/ethereum/execution-specs/blob/tests-v5.4.0/tests/berlin/eip2930_access_list/test_acl.py#L117",
+   "fixture-format": "state_test",
+   "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2930.md",
+   "reference-spec-version": "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
+  }
+ },
+ "tests/berlin/eip2930_access_list/test_acl.py::test_transaction_intrinsic_gas_cost[fork_Cancun-state_test-not_enough_gas-repeated_address_multiple_storage_keys]": {
+  "env": {
+   "currentCoinbase": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+   "currentGasLimit": "0x07270e00",
+   "currentNumber": "0x01",
+   "currentTimestamp": "0x03e8",
+   "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "currentDifficulty": "0x00",
+   "currentBaseFee": "0x07",
+   "currentExcessBlobGas": "0x00"
+  },
+  "pre": {
+   "0xa5bce600a5cf88bea8363531f788da975cd28400": {
+    "nonce": "0x01",
+    "balance": "0x03",
+    "code": "0x00",
+    "storage": {}
+   },
+   "0xfbb7941c3e6b61dc9a19f23c41e33bacc953f53a": {
+    "nonce": "0x00",
+    "balance": "0x3635c9adc5dea00001",
+    "code": "0x",
+    "storage": {}
+   }
+  },
+  "transaction": {
+   "nonce": "0x00",
+   "gasPrice": "0x0a",
+   "gasLimit": [
+    "0x8277"
+   ],
+   "to": "0xa5bce600a5cf88bea8363531f788da975cd28400",
+   "value": [
+    "0x01"
+   ],
+   "data": [
+    "0x"
+   ],
+   "accessLists": [
+    [
+     {
+      "address": "0x0000000000000000000000000000000000000000",
+      "storageKeys": [
+       "0x0000000000000000000000000000000000000000000000000000000000000000",
+       "0x0000000000000000000000000000000000000000000000000000000000000001"
+      ]
+     },
+     {
+      "address": "0x0000000000000000000000000000000000000000",
+      "storageKeys": [
+       "0x0000000000000000000000000000000000000000000000000000000000000000",
+       "0x0000000000000000000000000000000000000000000000000000000000000001"
+      ]
+     }
+    ]
+   ],
+   "sender": "0xfbb7941c3e6b61dc9a19f23c41e33bacc953f53a",
+   "secretKey": "0x911c68c173b8a8f36a1ed08ba5bce600a5cf88bea8363531f788da975cd28400"
+  },
+  "post": {
+   "Cancun": [
+    {
+     "hash": "0x53d34aff80763c762f0ae0247b004f6b90476359938dc1737542057f109ddaad",
+     "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+     "txbytes": "0x01f9011801800a82827794a5bce600a5cf88bea8363531f788da975cd284000180f8b6f859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000001f859940000000000000000000000000000000000000000f842a00000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000101a0af45317ec26a3f889b4d914d5af660efe8a8925c37a9cbf9261654a4c8c15610a06b954d333b8d78c6ed400ae71f0212df7c81f1275b78200a0b9d1dacfaf4539c",
+     "indexes": {
+      "data": 0,
+      "gas": 0,
+      "value": 0
+     },
+     "state": {
+      "0xa5bce600a5cf88bea8363531f788da975cd28400": {
+       "nonce": "0x01",
+       "balance": "0x03",
+       "code": "0x00",
+       "storage": {}
+      },
+      "0xfbb7941c3e6b61dc9a19f23c41e33bacc953f53a": {
+       "nonce": "0x00",
+       "balance": "0x3635c9adc5dea00001",
+       "code": "0x",
+       "storage": {}
+      }
+     },
+     "expectException": "TransactionException.INTRINSIC_GAS_TOO_LOW"
+    }
+   ]
+  },
+  "config": {
+   "blobSchedule": {
+    "Cancun": {
+     "target": "0x03",
+     "max": "0x06",
+     "baseFeeUpdateFraction": "0x32f0ed"
+    }
+   },
+   "chainid": "0x01"
+  },
+  "_info": {
+   "hash": "0x8d82ab6f5bda688512cb687ef3c45676ee91252397d905ead11927ceadfadf45",
+   "comment": "`execution-specs` generated test",
+   "filling-transition-tool": "2.18.0rc6",
+   "description": "Test type 1 transaction.",
+   "url": "https://github.com/ethereum/execution-specs/blob/tests-v5.4.0/tests/berlin/eip2930_access_list/test_acl.py#L117",
+   "fixture-format": "state_test",
+   "reference-spec": "https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2930.md",
+   "reference-spec-version": "c9db53a936c5c9cbe2db32ba0d1b86c4c6e73534"
+  }
+ }
+}

--- a/spec/src/trie.zig
+++ b/spec/src/trie.zig
@@ -1,0 +1,213 @@
+//! Merkle Patricia Trie root computation, used to verify post-state roots from
+//! specification test fixtures. Only root computation over a known key/value
+//! set is implemented; there is no node storage, proof generation, or deletion.
+//!
+//! Keys given to `secureRoot` are hashed with Keccak-256 first ("secure" trie),
+//! which is how both the world state trie and account storage tries key their
+//! content.
+//!
+//! Ref: YP Appendix D.
+
+const std = @import("std");
+const Keccak256 = std.crypto.hash.sha3.Keccak256;
+
+const rlp = @import("rlp.zig");
+
+const Bytes = std.ArrayListUnmanaged(u8);
+
+/// Keccak-256 of the RLP empty string (0x80); root of the empty trie.
+pub const EMPTY_ROOT = [32]u8{
+    0x56, 0xe8, 0x1f, 0x17, 0x1b, 0xcc, 0x55, 0xa6, 0xff, 0x83, 0x45, 0xe6, 0x92, 0xc0, 0xf8, 0x6e,
+    0x5b, 0x48, 0xe0, 0x1b, 0x99, 0x6c, 0xad, 0xc0, 0x01, 0x62, 0x2f, 0xb5, 0xe3, 0x63, 0xb4, 0x21,
+};
+
+/// Keccak-256 of the RLP empty byte string; code hash of a codeless account.
+pub const EMPTY_CODE_HASH = [32]u8{
+    0xc5, 0xd2, 0x46, 0x01, 0x86, 0xf7, 0x23, 0x3c, 0x92, 0x7e, 0x7d, 0xb2, 0xdc, 0xc7, 0x03, 0xc0,
+    0xe5, 0x00, 0xb6, 0x53, 0xca, 0x82, 0x27, 0x3b, 0x7b, 0xfa, 0xd8, 0x04, 0x5d, 0x85, 0xa4, 0x70,
+};
+
+/// One trie entry. `key` is the raw (pre-hash) key; `value` must already be
+/// RLP-encoded.
+pub const Pair = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+/// Compute the root of a secure trie containing `pairs`. Allocation is assumed
+/// to be arena-backed; nothing is individually freed.
+pub fn secureRoot(alloc: std.mem.Allocator, pairs: []const Pair) ![32]u8 {
+    if (pairs.len == 0) return EMPTY_ROOT;
+
+    // Secure trie: actual trie keys are the Keccak-256 hashes of the given
+    // keys, expanded to nibbles (so always 64 nibbles long here).
+    const entries = try alloc.alloc(Entry, pairs.len);
+    for (pairs, 0..) |pair, i| {
+        var hashed: [32]u8 = undefined;
+        Keccak256.hash(pair.key, &hashed, .{});
+
+        const nibbles = try alloc.alloc(u4, 64);
+        for (hashed, 0..) |byte, j| {
+            nibbles[2 * j] = @intCast(byte >> 4);
+            nibbles[2 * j + 1] = @intCast(byte & 0x0f);
+        }
+
+        entries[i] = .{ .nibbles = nibbles, .value = pair.value };
+    }
+
+    std.mem.sort(Entry, entries, {}, Entry.lessThan);
+
+    // Hashed keys are unique unless the caller passed duplicate keys.
+    for (entries[1..], 0..) |entry, i| {
+        std.debug.assert(!std.mem.eql(u4, entry.nibbles, entries[i].nibbles));
+    }
+
+    const node = try encodeNode(alloc, entries, 0);
+
+    var root: [32]u8 = undefined;
+    Keccak256.hash(node, &root, .{});
+    return root;
+}
+
+const Entry = struct {
+    nibbles: []const u4,
+    value: []const u8,
+
+    fn lessThan(_: void, a: Entry, b: Entry) bool {
+        return std.mem.lessThan(u4, a.nibbles, b.nibbles);
+    }
+};
+
+/// Returns the RLP encoding of the node containing `entries`, all of which
+/// share their first `depth` nibbles. `entries` must be sorted and non-empty.
+fn encodeNode(alloc: std.mem.Allocator, entries: []const Entry, depth: usize) ![]const u8 {
+    std.debug.assert(entries.len > 0);
+
+    // Leaf node: [HP(remaining path, leaf), value]
+    if (entries.len == 1) {
+        const entry = entries[0];
+
+        var payload: Bytes = .empty;
+        try rlp.encodeBytes(alloc, &payload, try hexPrefix(alloc, entry.nibbles[depth..], true));
+        try rlp.encodeBytes(alloc, &payload, entry.value);
+
+        var node: Bytes = .empty;
+        try rlp.encodeList(alloc, &node, payload.items);
+        return node.items;
+    }
+
+    // Find the longest prefix (from depth) common to all entries. Since
+    // entries are sorted it suffices to compare the first against the last.
+    const first = entries[0].nibbles;
+    const last = entries[entries.len - 1].nibbles;
+
+    var common: usize = 0;
+    while (depth + common < first.len and first[depth + common] == last[depth + common]) common += 1;
+
+    // Extension node: [HP(common path, not-leaf), child reference]
+    if (common > 0) {
+        const child = try encodeNode(alloc, entries, depth + common);
+
+        var payload: Bytes = .empty;
+        try rlp.encodeBytes(alloc, &payload, try hexPrefix(alloc, first[depth .. depth + common], false));
+        try appendReference(alloc, &payload, child);
+
+        var node: Bytes = .empty;
+        try rlp.encodeList(alloc, &node, payload.items);
+        return node.items;
+    }
+
+    // Branch node: [child 0, ..., child 15, value]
+    var payload: Bytes = .empty;
+
+    var start: usize = 0;
+    for (0..16) |nibble| {
+        var end = start;
+        while (end < entries.len and entries[end].nibbles[depth] == nibble) end += 1;
+
+        if (end == start) {
+            try payload.append(alloc, 0x80); // Empty child slot.
+        } else {
+            const child = try encodeNode(alloc, entries[start..end], depth + 1);
+            try appendReference(alloc, &payload, child);
+        }
+
+        start = end;
+    }
+
+    // Secure-trie keys all have equal (64 nibble) length so no key can
+    // terminate at a branch; the value slot is always empty.
+    try payload.append(alloc, 0x80);
+
+    var node: Bytes = .empty;
+    try rlp.encodeList(alloc, &node, payload.items);
+    return node.items;
+}
+
+/// Append a child node reference: nodes whose RLP is at least 32 bytes are
+/// referenced by hash, shorter nodes are embedded directly.
+fn appendReference(alloc: std.mem.Allocator, out: *Bytes, node: []const u8) !void {
+    if (node.len >= 32) {
+        var hash: [32]u8 = undefined;
+        Keccak256.hash(node, &hash, .{});
+        try rlp.encodeBytes(alloc, out, &hash);
+    } else {
+        try out.appendSlice(alloc, node);
+    }
+}
+
+/// Hex-prefix encode a nibble path: flag bit 2 marks a leaf, bit 1 odd length.
+/// Ref: YP Appendix C.
+fn hexPrefix(alloc: std.mem.Allocator, nibbles: []const u4, leaf: bool) ![]const u8 {
+    const flag: u8 = if (leaf) 2 else 0;
+    const odd = nibbles.len % 2 == 1;
+
+    const out = try alloc.alloc(u8, 1 + nibbles.len / 2);
+
+    var i: usize = 0;
+    if (odd) {
+        out[0] = (flag + 1) << 4 | nibbles[0];
+        i = 1;
+    } else {
+        out[0] = flag << 4;
+    }
+
+    var j: usize = 1;
+    while (i < nibbles.len) : ({
+        i += 2;
+        j += 1;
+    }) {
+        out[j] = @as(u8, nibbles[i]) << 4 | nibbles[i + 1];
+    }
+
+    return out;
+}
+
+test "empty trie root constant" {
+    // EMPTY_ROOT must be the hash of the RLP empty string.
+    var hash: [32]u8 = undefined;
+    Keccak256.hash(&[_]u8{0x80}, &hash, .{});
+    try std.testing.expectEqualSlices(u8, &EMPTY_ROOT, &hash);
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    try std.testing.expectEqual(EMPTY_ROOT, try secureRoot(arena.allocator(), &.{}));
+}
+
+test "empty code hash constant" {
+    var hash: [32]u8 = undefined;
+    Keccak256.hash(&[_]u8{}, &hash, .{});
+    try std.testing.expectEqualSlices(u8, &EMPTY_CODE_HASH, &hash);
+}
+
+test "hex-prefix encoding" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    // Examples from YP Appendix C.
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x11, 0x23, 0x45 }, try hexPrefix(alloc, &[_]u4{ 1, 2, 3, 4, 5 }, false));
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x00, 0x01, 0x23, 0x45 }, try hexPrefix(alloc, &[_]u4{ 0, 1, 2, 3, 4, 5 }, false));
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x20, 0x0f, 0x1c, 0xb8 }, try hexPrefix(alloc, &[_]u4{ 0, 0xf, 1, 0xc, 0xb, 8 }, true));
+    try std.testing.expectEqualSlices(u8, &[_]u8{ 0x3f, 0x1c, 0xb8 }, try hexPrefix(alloc, &[_]u4{ 0xf, 1, 0xc, 0xb, 8 }, true));
+}

--- a/spec/src/vendored_test.zig
+++ b/spec/src/vendored_test.zig
@@ -1,0 +1,59 @@
+//! Integration test: run vendored execution-spec-tests fixtures end to end
+//! (parse, state transition, zevem execution, post-state verification).
+//!
+//! The files under testdata/ are verbatim test cases extracted from the
+//! pinned EEST release (see spec/README.org for provenance), chosen because
+//! zevem can execute them fully today; they must always pass. Broader
+//! conformance runs use `just fetch-fixtures` + `just spec` against the
+//! complete release.
+
+const std = @import("std");
+
+const fixture = @import("fixture.zig");
+const runner = @import("runner.zig");
+
+const vendored = [_][]const u8{
+    // Pure stack-op execution ending in an exceptional halt; exercises EVM
+    // invocation and all-gas-consumed accounting.
+    @embedFile("testdata/stack_underflow.json"),
+    // Access-list transactions with exactly-enough and not-enough intrinsic
+    // gas; exercises validation, access list gas, and the rejection path.
+    @embedFile("testdata/transaction_intrinsic_gas_cost.json"),
+};
+
+test "vendored fixtures pass" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const alloc = arena.allocator();
+
+    var pass: usize = 0;
+    var pass_exception: usize = 0;
+
+    for (vendored) |bytes| {
+        const cases = try fixture.parseSlice(alloc, bytes);
+
+        for (cases) |case| {
+            var results = std.ArrayListUnmanaged(runner.EntryResult).empty;
+            try runner.runCase(alloc, case, "Cancun", &results);
+
+            for (results.items) |result| {
+                switch (result.outcome) {
+                    .pass => pass += 1,
+                    .pass_exception => pass_exception += 1,
+                    .skip => |reason| {
+                        std.debug.print("vendored fixture skipped: {s} [{d}]: {s}\n", .{ result.case_name, result.entry_index, reason.describe() });
+                        return error.VendoredFixtureSkipped;
+                    },
+                    .fail => |message| {
+                        std.debug.print("vendored fixture failed: {s} [{d}]\n{s}\n", .{ result.case_name, result.entry_index, message });
+                        return error.VendoredFixtureFailed;
+                    },
+                }
+            }
+        }
+    }
+
+    // Both the executed and the expected-rejection paths must be covered.
+    try std.testing.expect(pass > 0);
+    try std.testing.expect(pass_exception > 0);
+}

--- a/src/lib/evm.zig
+++ b/src/lib/evm.zig
@@ -751,18 +751,26 @@ pub fn New(comptime Environment: type) type {
 
                     // TODO: Since this isn't a zkEVM make sure any side-channel proections are disabled for any calls to hash.
 
-                    // FIXME: Two intCasts to usize for std.mem.items slice, problem or not?
-                    const offset: usize = @intCast(self.stack.pop().?);
-                    const length: usize = @intCast(self.stack.pop().?);
+                    const offset_word = self.stack.pop().?;
+                    const length_word = self.stack.pop().?;
+
+                    // A zero length reads no memory so any offset is legal
+                    // (and the memory sizing function will not have expanded
+                    // for it, making the casts below unsafe); for a non-zero
+                    // length the sizing function has already expanded memory
+                    // to cover the range or returned OutOfGas.
+                    const region: []const u8 = if (length_word == 0) &.{} else blk: {
+                        const offset: usize = @intCast(offset_word);
+                        const length: usize = @intCast(length_word);
+                        break :blk self.mem.items[offset..(offset + length)];
+                    };
 
                     // TODO: Hash directly into the stack instead of this intermediate variable?
                     var digest = [_]u8{0} ** 32;
 
-                    // print("Hashing: {x}\n", .{                        self.mem.items[offset..(offset + length)]});
-
                     std.crypto.hash.sha3.Keccak256.hash(
                         // Note: The `- 1` in YP is wrong.
-                        @ptrCast(self.mem.items[offset..(offset + length)]),
+                        region,
                         &digest,
                         .{},
                     );
@@ -821,7 +829,13 @@ pub fn New(comptime Environment: type) type {
 
                     continue :sw try self.nextOp(rom);
                 },
-                .CALLDATACOPY => {},
+                .CALLDATACOPY => {
+                    // TODO: Implement.
+                    // NB: An empty prong here is not a no-op: with no
+                    //     `continue :sw` the labelled switch simply ends, so
+                    //     execution silently halted as if it succeeded.
+                    return error.NotImplemented;
+                },
                 .CODESIZE => {
                     // Push I_b onto stack.
 
@@ -946,7 +960,16 @@ pub fn New(comptime Environment: type) type {
                 },
                 .JUMP => {
                     // s[0] = new program counter value
-                    const new_pc: @TypeOf(self.pc) = @intCast(self.stack.pop().?);
+                    const target = self.stack.pop().?;
+
+                    // NB: Bound-check against the bytecode before narrowing:
+                    //     a Word-sized target would trap in @intCast, and one
+                    //     past the bytecode would assert inside the bitset.
+                    if (target >= rom.len) {
+                        return Exception.InvalidJumpDestination;
+                    }
+
+                    const new_pc: @TypeOf(self.pc) = @intCast(target);
 
                     if (valid_jumpdests.isSet(new_pc) == false) {
                         return Exception.InvalidJumpDestination;
@@ -958,11 +981,18 @@ pub fn New(comptime Environment: type) type {
                 },
                 .JUMPI => {
                     // s[0] = potential new program counter value ; s[1] = check condition
-                    const new_pc: @TypeOf(self.pc) = @intCast(self.stack.pop().?);
+                    const target = self.stack.pop().?;
                     const condition = self.stack.pop().?;
 
                     // Non-zero condition = set new program counter.
                     if (condition > 0) {
+                        // NB: As in JUMP, bound-check before narrowing.
+                        if (target >= rom.len) {
+                            return Exception.InvalidJumpDestination;
+                        }
+
+                        const new_pc: @TypeOf(self.pc) = @intCast(target);
+
                         if (valid_jumpdests.isSet(new_pc) == false) {
                             return Exception.InvalidJumpDestination;
                         }
@@ -1018,23 +1048,26 @@ pub fn New(comptime Environment: type) type {
                     };
                     defer if (config.use_tracy) zt.deinit();
 
-                    // TODO: YP for PUSH1 to PUSH32 defines function c:
-                    // "The function c ensures the bytes default to zero if they extend past the limits"
-                    // ^^^ Make sure we're doing this. Add a test trying to push outside bytecode range, it should succeed.
-
                     // Offset vs PUSH0 is amount of bytes to read forward and push onto stack as
                     // this instructions operand.
                     const offset = @intFromEnum(op) - @intFromEnum(OpCode.PUSH0);
 
-                    const operand_bytes = rom[self.pc..][0..offset];
+                    // YP for PUSH1 to PUSH32 defines function c: "The function
+                    // c ensures the bytes default to zero if they extend past
+                    // the limits", so an operand truncated by the end of the
+                    // bytecode is padded with trailing zeroes (and slicing rom
+                    // directly would be out of bounds).
+                    var operand_bytes = [_]u8{0} ** 32;
+                    const available = @min(offset, rom.len - self.pc);
+                    @memcpy(operand_bytes[0..available], rom[self.pc..][0..available]);
 
                     // std.mem.readInt does not 0-pad types less than requested size, so we construct and reify the `type` we need then upcast to Word.
                     const operand = @as(Word, std.mem.readInt(
                         @Type(.{ .int = .{
                             .signedness = .unsigned,
-                            .bits = 8 * operand_bytes.len,
+                            .bits = 8 * @as(u16, offset),
                         } }),
-                        operand_bytes,
+                        operand_bytes[0..offset],
                         .big,
                     ));
 
@@ -1174,12 +1207,24 @@ pub fn New(comptime Environment: type) type {
                     const offset = self.stack.pop().?;
                     const size = self.stack.pop().?;
 
-                    self.return_data = try self.alloc.alloc(u8, @truncate(size));
+                    // A size that cannot even be addressed is unpayable
+                    // memory expansion by definition.
+                    const size_usize = std.math.cast(usize, size) orelse return Exception.OutOfGas;
 
-                    if (offset < self.mem.items.len) {
-                        const end = @min(offset + size, self.mem.items.len);
+                    self.return_data = try self.alloc.alloc(u8, size_usize);
 
-                        @memcpy(self.return_data[0..], self.mem.items[@truncate(offset)..end]);
+                    // TODO: Memory expansion (and its gas) should happen ahead
+                    //       of this read per spec; until that lands, the part
+                    //       of the range beyond current memory reads as zeroes
+                    //       (expanded memory is zero-filled anyway, so only
+                    //       the unpaid gas is missing).
+                    @memset(self.return_data, 0);
+
+                    if (offset < self.mem.items.len and size_usize != 0) {
+                        const start: usize = @intCast(offset);
+                        const end: usize = @intCast(@min(offset + size, self.mem.items.len));
+
+                        @memcpy(self.return_data[0 .. end - start], self.mem.items[start..end]);
                     }
 
                     if (op == .REVERT) return Exception.Revert;

--- a/src/lib/op.zig
+++ b/src/lib/op.zig
@@ -123,7 +123,10 @@ const fee_map = EnumMap(FeeSchedule, u16).init(.{
     .copy = 3,
     .blockhash = 20,
     // TODO: Remove this field later.
-    // .TODO_CUSTOM_FEE = 42069,
+    // NB: Must be present (even as zero) until then: opcodes tagged with it
+    // otherwise panic at the fee lookup in nextOp before their handler can
+    // return NotImplemented / Orchestrate.
+    .TODO_CUSTOM_FEE = 0,
 });
 
 // TODO: Largest actual delta or alpha appears to be 7, so 3 bits, but using 5 to keep things more literal for now (i.e. SWAP and DUP large delta/alpha in yellowpaper).
@@ -503,7 +506,10 @@ fn gasSimpleMemory(self: *EVM, u_i__expanded: u64) Exception!u64 {
     const u_i__change = u_i__expanded - u_i__current;
 
     // 0x1FFFFFFFE0 yoinked from Geth when trying to optimise ludicrous change deltas near u64 max.
-    if (u_i__change > 0x1fffffffe0) {
+    // NB: Geth's ceiling is in _bytes_; ours is a count of words so divide it
+    //     by 32 (giving 0xFFFFFFFF), which also keeps the square below fitting
+    //     within u64 (otherwise `u_i__change * u_i__change` can overflow).
+    if (u_i__change > 0xffffffff) {
         return Exception.OutOfGas;
     }
 
@@ -527,7 +533,9 @@ pub const annotation = MakeOpAnnotations(.{
     .{ .{.BYTE}, .{ .{ "msb_offset", "operand" }, .{"result"} } },
     .{ .{ .SHL, .SHR, .SAR }, .{ .{ "bits", "operand" }, .{"result"} } },
     .{ .{.KECCAK256}, .{ .{ "offset", "length" }, .{"digest"} } },
-    .{ .{.CALLDATASIZE}, .{ .{"size"}, .{} } },
+    // NB: CALLDATASIZE pops nothing; "size" is what it pushes. A delta entry
+    // here panics the annotation printing when the stack is empty.
+    .{ .{.CALLDATASIZE}, .{ .{}, .{"size"} } },
     .{ .{.ORIGIN}, .{ .{}, .{"addr"} } },
     .{ .{.POP}, .{ .{"discard"}, .{} } },
     .{ .{.MLOAD}, .{ .{"offset"}, .{"bytes"} } },
@@ -775,8 +783,16 @@ fn getMemorySizeChange(s: types.Word, f: types.Word, l: types.Word) Exception!u6
         return Exception.MemResizeUInt256Overflow;
     }
 
-    // Treating as as u64, all the while that's true just truncate here since we'll hit out of gas later anyway.
-    return @truncate(@max(s, u_i__after));
+    // NB: Cannot simply @truncate to u64 here: for ludicrous (but not
+    //     u256-overflowing) addresses the truncated word count can wrap to a
+    //     small value, pass the gas check, and then the opcode body's slice
+    //     arithmetic panics. Any word count above the unpayable ceiling (same
+    //     0xFFFFFFFF as in gasSimpleMemory) is out of gas by definition.
+    const max_words = @max(s, u_i__after);
+    if (max_words > 0xffffffff) {
+        return Exception.OutOfGas;
+    }
+    return @intCast(max_words);
     // const res: u64 = @truncate(@max(s, u_i__after));
     // print("calculateMemoryCost s={d}, f={d}, l={d} -- {d}, {d}, {d} -- {d}\n", .{ s, f, l, u_i__before, u_i__after, new_max_address[0], res });
     // return res;

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,8 +16,8 @@ pub fn main() !void {
 
     var gpa: std.heap.DebugAllocator(.{}) = .init;
     const allocator = gpa.allocator();
-    var dummyEnv = zevem.DummyEnv{ .block = .default };
+    var dummyEnv: zevem.DummyEnv = .default;
     var evm2 = try EVM.init(allocator, &dummyEnv);
-    try evm2.execute(.{ .sender = 0, .gas = 100_000, .code = &.{ 0x5F, 0x60, 0x11, 0x61, 0x22, 0x33, 0x00 }, .data = "" });
+    try evm2.execute(.{ .sender = 0, .target = 0, .value = 0, .gas = 100_000, .gas_price = 0, .code = &.{ 0x5F, 0x60, 0x11, 0x61, 0x22, 0x33, 0x00 }, .data = "" });
     print("Done!", .{});
 }


### PR DESCRIPTION
Following up on our conversation about hooking up the official execution specs so zevem can run against real test data.

This adds a self-contained harness under `spec/` that consumes [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) (EEST) state test fixtures with zevem as the EVM. zevem stays just-the-EVM: the harness acts as the host, owning world state and the state transition around execution (Cancun rules), then verifies the post state two ways — account-by-account against the fixture's `post.state` (precise diffs for debugging), and via the state root against `post.hash` (secure Merkle Patricia Trie over RLP-encoded accounts, implemented in `spec/src/trie.zig` / `rlp.zig` and validated against fixture ground truth).

## Usage

```sh
just fetch-fixtures   # pinned EEST release (v5.4.0), state tests only
just spec spec/fixtures/v5.4.0/fixtures/state_tests
```

Flags: `--fork=NAME` (default Cancun), `--verbose`, `--max=N`, `--strict` (non-zero exit on fail, for CI), `--evm-trace` (keep the per-opcode stderr tracing, otherwise silenced).

## Reporting

Every post entry lands in exactly one bucket, nothing is silently dropped:

```
zevem-spec: fork Cancun
------------------------------------------------------------------------
entries:         44039
pass:            846
pass (rejected): 372
fail:            69
skip:            42752
  fork_filtered: 27192 (post entries for a non-selected fork)
  tx_type_unsupported: 898 (unsupported transaction type (blob or set-code))
  evm_unimplemented: 14461 (opcode not implemented by zevem yet)
  evm_orchestrate: 157 (needs host orchestration (CREATE/CALL pending in zevem))
  precompile_unsupported: 20 (transaction targets a precompile; precompiles pending)
  logs_uncollected: 24 (fixture expects logs; zevem does not collect logs yet)
```

The skip breakdown doubles as a progress tracker: when an opcode family lands, its entries move from skip into pass/fail, and fails come with account-level diffs to debug against. The remaining 69 fails are genuine semantic findings (memory-stress gas edges, LOG gas, create-collision-revert nuances, BALANCE returning a hardcoded zero) rather than harness noise.

## Core fixes (first commit)

Running real fixtures immediately surfaced crashes in the interpreter, all reachable with valid bytecode — details in the commit message, summary:

- `TODO_CUSTOM_FEE` had no `fee_map` entry, so CALL/SLOAD/copies/etc. panicked at the fee lookup before their handler could return `NotImplemented`.
- The Geth-derived memory ceiling (`0x1FFFFFFFE0`) is a byte count but was compared against word counts, so `change * change` could overflow u64; and `getMemorySizeChange` @truncate'd word counts, letting ludicrous offsets wrap small, pass the gas check, then panic in opcode slice arithmetic.
- JUMP/JUMPI: Word-sized or just-past-the-end targets trapped/asserted instead of `InvalidJumpDestination`.
- PUSH operands extending past the bytecode now zero-pad per YP function c (your existing TODO).
- KECCAK256 with zero length but huge offset trapped despite reading no memory.
- RETURN/REVERT panicked in @memcpy when the range exceeded current memory (expansion gas for these stays TODO; the unexpanded part reads as zeroes).
- CALLDATACOPY's stub was an empty switch prong with no `continue :sw`, silently ending execution as success — this one alone accounted for ~1000 false fixture failures.
- CALLDATASIZE's trace annotation declared its push as a pop, panicking the annotation printer on an empty stack.
- `src/main.zig` (CLI) didn't compile against the current DummyEnv/Transaction shapes (CI only builds tests, so it went unnoticed).

Your 49 existing unit tests pass unchanged (debug and release-fast, Zig 0.14.0 and 0.14.1).

## Deliberately not touched (your design space)

- The CREATE/CALL resume/orchestration API: `error.Orchestrate` is reported as a skip; once your resume design lands the harness is the natural driver for it.
- Log collection (LOG entry ownership is an open design decision per PROJECT.org); entries whose fixtures expect logs are skipped with a reason.
- One finding worth knowing: `evm.New` is currently only instantiable with `DummyEnv`, because op.zig's dynamic gas function pointers are typed against `New(DummyEnv)` specifically. The harness therefore drives `DummyEnv` directly. Generalising that (probably making the op table comptime over the environment) felt like your call, happy to take a crack at it if you want.

## Tests / CI

Harness unit tests (RLP vectors, trie hex-prefix + empty-root + a state root checked against a fixture-declared hash, fixture parsing, created-address derivation) plus an end-to-end vendored-fixture test join `zig build test`. The vendored files under `spec/src/testdata/` are verbatim test cases extracted from the pinned release, chosen because zevem fully executes them today — they must always pass.

Happy to split this differently, rename things, or adjust the reporting format to taste.